### PR TITLE
プラグインシステムの設計とローダー実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,215 @@ npm run tauri:dev
 npm run tauri:build
 ```
 
+## プラグインシステム
+
+qcut はプラグインシステムを備えており、TypeScript プラグインと WASM プラグインの両方をサポートしています。
+
+### アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  qcut App                                               │
+│                                                         │
+│  ┌──────────┐   ┌──────────────┐   ┌────────────────┐  │
+│  │ App.tsx  │──▶│PluginManager │──▶│  pluginStore    │  │
+│  └──────────┘   │ (lifecycle)  │   │  (Zustand)     │  │
+│                 └──────┬───────┘   └────────────────┘  │
+│                        │                                │
+│            ┌───────────┼───────────┐                    │
+│            ▼           ▼           ▼                    │
+│     ┌────────────┐ ┌────────┐ ┌──────────────┐         │
+│     │PluginLoader│ │Context │ │WasmWrapper   │         │
+│     │ discover() │ │ (API)  │ │processFrame()│         │
+│     │ load()     │ │        │ │              │         │
+│     └─────┬──────┘ └───┬────┘ └──────┬───────┘         │
+│           │            │             │                  │
+│     ┌─────▼──────┐  ┌──▼───────────┐│                  │
+│     │Tauri Commands│ │Zustand Stores││                  │
+│     │list_plugin_ │ │timelineStore ││                  │
+│     │  dirs       │ │videoPreview  ││                  │
+│     │read_plugin_ │ │  Store       ││                  │
+│     │  manifest   │ └──────────────┘│                  │
+│     │read_plugin_ │                 │                  │
+│     │  file       │                 │                  │
+│     └─────┬───────┘                 │                  │
+│           │                         │                  │
+└───────────┼─────────────────────────┼──────────────────┘
+            ▼                         ▼
+┌───────────────────┐  ┌──────────────────────────┐
+│ {app_data_dir}/   │  │  WASM Linear Memory      │
+│  plugins/         │  │  ┌─────────┐ ┌─────────┐ │
+│   my-plugin/      │  │  │ input   │ │ output  │ │
+│    plugin.json    │  │  │ (RGBA)  │ │ (RGBA)  │ │
+│    index.js       │  │  └─────────┘ └─────────┘ │
+│    index.wasm     │  └──────────────────────────┘
+│  plugin-settings  │
+│    .json          │
+└───────────────────┘
+```
+
+### プラグインの種類
+
+| 種類 | 用途 | エントリ |
+|------|------|----------|
+| `typescript` | UI拡張、設定パネル、カスタムツール | `index.js` (ESM) |
+| `wasm` | フレーム処理、フィルタ、エフェクト | `index.wasm` |
+| `hybrid` | TS で UI + WASM で計算 | 両方 |
+
+### プラグインの作り方
+
+#### 1. ディレクトリを作成
+
+```
+{app_data_dir}/plugins/my-plugin/
+├── plugin.json
+├── index.js       # TypeScript プラグイン
+└── index.wasm     # WASM プラグイン（オプション）
+```
+
+#### 2. マニフェスト（plugin.json）を書く
+
+```json
+{
+  "id": "com.example.my-effect",
+  "name": "My Effect",
+  "version": "1.0.0",
+  "description": "サンプルエフェクトプラグイン",
+  "author": "Your Name",
+  "type": "typescript",
+  "entry": {
+    "js": "index.js"
+  },
+  "permissions": [
+    "timeline:read",
+    "preview:read",
+    "ui:panel"
+  ],
+  "minAppVersion": "0.1.0",
+  "category": "effect"
+}
+```
+
+#### 3. プラグイン本体を実装
+
+**TypeScript プラグイン（index.js）:**
+
+```javascript
+export default {
+  async onInit(context) {
+    context.log.info('プラグイン初期化');
+
+    // タイムラインの変更を監視
+    context.timeline.onTimeChange((time) => {
+      context.log.info(`現在時刻: ${time}`);
+    });
+
+    // UIパネルを登録
+    context.ui.registerPanel({
+      id: 'my-panel',
+      title: 'My Effect',
+      location: 'sidebar',
+      render: (container) => {
+        container.innerHTML = '<p>Hello from plugin!</p>';
+      },
+    });
+  },
+
+  async onActivate() {
+    // プラグイン有効化時の処理
+  },
+
+  async onDeactivate() {
+    // プラグイン無効化時の処理
+  },
+};
+```
+
+**WASM プラグイン（Rust で実装 → .wasm にコンパイル）:**
+
+```rust
+#[no_mangle]
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
+    let mut buf = Vec::with_capacity(size);
+    let ptr = buf.as_mut_ptr();
+    std::mem::forget(buf);
+    ptr
+}
+
+#[no_mangle]
+pub extern "C" fn dealloc(ptr: *mut u8, size: usize) {
+    unsafe { Vec::from_raw_parts(ptr, 0, size); }
+}
+
+/// RGBA フレームデータを処理（例: グレースケール変換）
+#[no_mangle]
+pub extern "C" fn process_frame(
+    input: *const u8, width: u32, height: u32, output: *mut u8
+) {
+    let len = (width * height * 4) as usize;
+    let input = unsafe { std::slice::from_raw_parts(input, len) };
+    let output = unsafe { std::slice::from_raw_parts_mut(output, len) };
+
+    for i in (0..len).step_by(4) {
+        let gray = (input[i] as u16 + input[i+1] as u16 + input[i+2] as u16) / 3;
+        output[i]     = gray as u8;  // R
+        output[i + 1] = gray as u8;  // G
+        output[i + 2] = gray as u8;  // B
+        output[i + 3] = input[i + 3]; // A
+    }
+}
+```
+
+### PluginContext API
+
+プラグインには `PluginContext` を通じて以下の API が提供されます。各 API はマニフェストの `permissions` で要求した権限に応じてアクセスが制御されます。
+
+| API | 必要な権限 | 説明 |
+|-----|-----------|------|
+| `context.timeline.getTracks()` | `timeline:read` | トラック一覧を取得 |
+| `context.timeline.getCurrentTime()` | `timeline:read` | 現在の再生位置を取得 |
+| `context.timeline.onTimeChange(cb)` | `timeline:read` | 再生位置の変更を監視 |
+| `context.timeline.addClip(...)` | `timeline:write` | クリップを追加 |
+| `context.timeline.updateClip(...)` | `timeline:write` | クリップを更新 |
+| `context.timeline.removeClip(...)` | `timeline:write` | クリップを削除 |
+| `context.preview.onFrameRender(cb)` | `frame:process` | フレーム描画時にフィルタを適用 |
+| `context.ui.registerPanel(config)` | `ui:panel` | UIパネルを追加 |
+| `context.ui.registerToolbarButton(config)` | `ui:toolbar` | ツールバーにボタンを追加 |
+| `context.settings.get(key, default)` | `settings:read` | プラグイン設定を読み取り |
+| `context.settings.set(key, value)` | `settings:write` | プラグイン設定を書き込み |
+| `context.log.info/warn/error(msg)` | なし | ログ出力 |
+
+### ライフサイクル
+
+```
+installed → loaded → initialized → active ⇄ inactive
+                                      ↓
+                                    error（自動隔離）
+```
+
+1. **installed**: プラグインディレクトリ検出、マニフェスト解析済み
+2. **loaded**: JS/WASM モジュールをメモリに読み込み済み
+3. **initialized**: `onInit()` 呼び出し完了
+4. **active**: `onActivate()` 呼び出し完了、フック登録済み
+5. **inactive**: `onDeactivate()` 呼び出し完了、フック解除済み
+6. **error**: エラー発生時に自動遷移。アプリ本体には影響しない
+
+### 利用可能な権限一覧
+
+| 権限 | 説明 |
+|------|------|
+| `timeline:read` | トラック・クリップデータの読み取り |
+| `timeline:write` | トラック・クリップの追加・変更・削除 |
+| `preview:read` | 現在のフレームデータの取得 |
+| `preview:write` | プレビューへのオーバーレイ描画 |
+| `file:read` | ファイルメタデータの読み取り |
+| `file:write` | ファイルの書き込み・エクスポート |
+| `settings:read` | アプリ設定の読み取り |
+| `settings:write` | アプリ設定の変更 |
+| `ui:panel` | UIパネルの登録 |
+| `ui:toolbar` | ツールバーボタンの登録 |
+| `frame:process` | WASM フレーム処理パイプライン |
+
 ## ライセンス
 
 MIT

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,13 @@ export default [
         KeyboardEvent: 'readonly',
         File: 'readonly',
         URL: 'readonly',
+        ImageData: 'readonly',
+        TextDecoder: 'readonly',
+        Blob: 'readonly',
+        WebAssembly: 'readonly',
+        Uint8Array: 'readonly',
+        Uint8ClampedArray: 'readonly',
+        ArrayBuffer: 'readonly',
       },
     },
     plugins: {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod video;
 pub mod files;
+pub mod plugins;
 

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -1,0 +1,114 @@
+use std::fs;
+use std::path::Path;
+use tauri::Manager;
+
+/// プラグインディレクトリ内のサブディレクトリ一覧を返す
+#[tauri::command]
+pub fn list_plugin_dirs(app_handle: tauri::AppHandle) -> Result<Vec<String>, String> {
+    let app_data = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir の取得に失敗: {}", e))?;
+
+    let plugins_dir = app_data.join("plugins");
+
+    if !plugins_dir.exists() {
+        fs::create_dir_all(&plugins_dir)
+            .map_err(|e| format!("プラグインディレクトリの作成に失敗: {}", e))?;
+        return Ok(vec![]);
+    }
+
+    let entries = fs::read_dir(&plugins_dir)
+        .map_err(|e| format!("プラグインディレクトリの読み込みに失敗: {}", e))?;
+
+    let dirs: Vec<String> = entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            if entry.file_type().ok()?.is_dir() {
+                entry.path().to_str().map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(dirs)
+}
+
+/// プラグインディレクトリ内の plugin.json を読み込む
+#[tauri::command]
+pub fn read_plugin_manifest(plugin_dir: String) -> Result<String, String> {
+    let manifest_path = Path::new(&plugin_dir).join("plugin.json");
+
+    if !manifest_path.exists() {
+        return Err(format!(
+            "plugin.json が見つかりません: {}",
+            manifest_path.display()
+        ));
+    }
+
+    fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("plugin.json の読み込みに失敗: {}", e))
+}
+
+/// プラグインファイルをバイト列として読み込む（JS/WASM 等）
+#[tauri::command]
+pub fn read_plugin_file(file_path: String) -> Result<Vec<u8>, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Err(format!("ファイルが見つかりません: {}", path.display()));
+    }
+
+    // セキュリティ: プラグインディレクトリ外のファイルへのアクセスを防止
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("パスの正規化に失敗: {}", e))?;
+
+    if !canonical
+        .to_str()
+        .map_or(false, |s| s.contains("plugins"))
+    {
+        return Err("プラグインディレクトリ外のファイルにはアクセスできません".to_string());
+    }
+
+    fs::read(&canonical).map_err(|e| format!("ファイルの読み込みに失敗: {}", e))
+}
+
+/// プラグイン設定ファイルを読み込む
+#[tauri::command]
+pub fn read_plugin_settings(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let app_data = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir の取得に失敗: {}", e))?;
+
+    let settings_path = app_data.join("plugin-settings.json");
+
+    if !settings_path.exists() {
+        return Ok("{}".to_string());
+    }
+
+    fs::read_to_string(&settings_path)
+        .map_err(|e| format!("設定ファイルの読み込みに失敗: {}", e))
+}
+
+/// プラグイン設定ファイルを書き込む
+#[tauri::command]
+pub fn write_plugin_settings(app_handle: tauri::AppHandle, content: String) -> Result<(), String> {
+    let app_data = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir の取得に失敗: {}", e))?;
+
+    let settings_path = app_data.join("plugin-settings.json");
+
+    // 親ディレクトリが存在することを確認
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("ディレクトリの作成に失敗: {}", e))?;
+    }
+
+    fs::write(&settings_path, content)
+        .map_err(|e| format!("設定ファイルの書き込みに失敗: {}", e))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,11 @@ pub fn run() {
       commands::video::get_video_info,
       commands::files::get_file_info,
       commands::files::open_file_dialog,
+      commands::plugins::list_plugin_dirs,
+      commands::plugins::read_plugin_manifest,
+      commands::plugins::read_plugin_file,
+      commands::plugins::read_plugin_settings,
+      commands::plugins::write_plugin_settings,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import './App.css';
 import Timeline from './components/Timeline/Timeline';
@@ -5,11 +6,24 @@ import { VideoPreview } from './components/VideoPreview/VideoPreview';
 import { FileOperations } from './components/FileOperations/FileOperations';
 import { useTimelineStore } from './store/timelineStore';
 import { useVideoPreviewStore } from './store/videoPreviewStore';
+import { PluginManager } from './plugin-system';
 
 function App() {
   const { t, i18n } = useTranslation();
   const { isPlaying, setIsPlaying } = useTimelineStore();
   const videoPreviewStore = useVideoPreviewStore();
+  const pluginManagerRef = useRef<PluginManager | null>(null);
+
+  useEffect(() => {
+    const manager = new PluginManager();
+    pluginManagerRef.current = manager;
+    manager.initialize().catch((e) => {
+      console.warn('[PluginManager] 初期化に失敗:', e);
+    });
+    return () => {
+      manager.shutdown();
+    };
+  }, []);
 
   // 言語切り替え
   const handleLanguageChange = (lang: string) => {

--- a/src/plugin-system/context.ts
+++ b/src/plugin-system/context.ts
@@ -1,0 +1,263 @@
+import { useTimelineStore } from '@/store/timelineStore';
+import type { Clip } from '@/store/timelineStore';
+import type { PluginManifest, PluginPermission } from './types/manifest';
+import type {
+  PluginContext,
+  PluginTimelineApi,
+  PluginPreviewApi,
+  PluginUiApi,
+  PluginSettingsApi,
+  PluginLogApi,
+  Disposable,
+  ClipChangeEvent,
+  PanelConfig,
+  ToolbarButtonConfig,
+} from './types/api';
+
+export class PluginPermissionError extends Error {
+  constructor(pluginId: string, permission: PluginPermission) {
+    super(`[${pluginId}] 権限 "${permission}" が許可されていません`);
+    this.name = 'PluginPermissionError';
+  }
+}
+
+export class PluginContextImpl implements PluginContext {
+  private permissions: Set<PluginPermission>;
+  private disposables: Disposable[] = [];
+  private pluginSettings: Record<string, unknown> = {};
+  private settingsListeners: Map<string, Set<(value: unknown) => void>> = new Map();
+
+  // 外部から登録されたパネル・ボタン・フレームコールバックを取得するための公開プロパティ
+  readonly registeredPanels: PanelConfig[] = [];
+  readonly registeredToolbarButtons: ToolbarButtonConfig[] = [];
+  readonly frameRenderCallbacks: Array<(frame: ImageData) => ImageData> = [];
+
+  constructor(
+    public readonly pluginId: string,
+    public readonly manifest: Readonly<PluginManifest>,
+  ) {
+    this.permissions = new Set(manifest.permissions);
+  }
+
+  get timeline(): PluginTimelineApi {
+    return {
+      getTracks: () => {
+        this.requirePermission('timeline:read');
+        return useTimelineStore.getState().tracks;
+      },
+
+      getClipById: (clipId: string): Clip | null => {
+        this.requirePermission('timeline:read');
+        const { tracks } = useTimelineStore.getState();
+        for (const track of tracks) {
+          const clip = track.clips.find((c) => c.id === clipId);
+          if (clip) return clip;
+        }
+        return null;
+      },
+
+      getCurrentTime: () => {
+        this.requirePermission('timeline:read');
+        return useTimelineStore.getState().currentTime;
+      },
+
+      onTimeChange: (callback: (time: number) => void): Disposable => {
+        this.requirePermission('timeline:read');
+        let prevTime = useTimelineStore.getState().currentTime;
+        const unsub = useTimelineStore.subscribe((state) => {
+          if (state.currentTime !== prevTime) {
+            prevTime = state.currentTime;
+            callback(state.currentTime);
+          }
+        });
+        const disposable = { dispose: unsub };
+        this.disposables.push(disposable);
+        return disposable;
+      },
+
+      onClipChange: (callback: (event: ClipChangeEvent) => void): Disposable => {
+        this.requirePermission('timeline:read');
+        let prevTracks = useTimelineStore.getState().tracks;
+        const unsub = useTimelineStore.subscribe((state) => {
+          if (state.tracks !== prevTracks) {
+            // 簡易的な変更検出（トラック参照が変わった場合に通知）
+            for (const track of state.tracks) {
+              const prevTrack = prevTracks.find((t) => t.id === track.id);
+              if (!prevTrack) continue;
+              for (const clip of track.clips) {
+                if (!prevTrack.clips.find((c) => c.id === clip.id)) {
+                  callback({ type: 'added', trackId: track.id, clipId: clip.id, clip });
+                }
+              }
+              for (const prevClip of prevTrack.clips) {
+                if (!track.clips.find((c) => c.id === prevClip.id)) {
+                  callback({ type: 'removed', trackId: track.id, clipId: prevClip.id });
+                }
+              }
+            }
+            prevTracks = state.tracks;
+          }
+        });
+        const disposable = { dispose: unsub };
+        this.disposables.push(disposable);
+        return disposable;
+      },
+
+      addClip: (trackId: string, clip: Omit<Clip, 'id'>): string => {
+        this.requirePermission('timeline:write');
+        const id = `plugin-clip-${Date.now()}`;
+        useTimelineStore.getState().addClip(trackId, { ...clip, id });
+        return id;
+      },
+
+      updateClip: (trackId: string, clipId: string, updates: Partial<Clip>) => {
+        this.requirePermission('timeline:write');
+        useTimelineStore.getState().updateClip(trackId, clipId, updates);
+      },
+
+      removeClip: (trackId: string, clipId: string) => {
+        this.requirePermission('timeline:write');
+        useTimelineStore.getState().removeClip(trackId, clipId);
+      },
+    };
+  }
+
+  get preview(): PluginPreviewApi {
+    return {
+      getCurrentFrameData: (): ImageData | null => {
+        this.requirePermission('preview:read');
+        // フレームデータの取得は VideoPreview との統合時に実装
+        return null;
+      },
+
+      onFrameRender: (callback: (frame: ImageData) => ImageData): Disposable => {
+        this.requirePermission('frame:process');
+        this.frameRenderCallbacks.push(callback);
+        const disposable = {
+          dispose: () => {
+            const idx = this.frameRenderCallbacks.indexOf(callback);
+            if (idx >= 0) this.frameRenderCallbacks.splice(idx, 1);
+          },
+        };
+        this.disposables.push(disposable);
+        return disposable;
+      },
+    };
+  }
+
+  get ui(): PluginUiApi {
+    return {
+      registerPanel: (config: PanelConfig): Disposable => {
+        this.requirePermission('ui:panel');
+        this.registeredPanels.push(config);
+        const disposable = {
+          dispose: () => {
+            const idx = this.registeredPanels.indexOf(config);
+            if (idx >= 0) this.registeredPanels.splice(idx, 1);
+          },
+        };
+        this.disposables.push(disposable);
+        return disposable;
+      },
+
+      registerToolbarButton: (config: ToolbarButtonConfig): Disposable => {
+        this.requirePermission('ui:toolbar');
+        this.registeredToolbarButtons.push(config);
+        const disposable = {
+          dispose: () => {
+            const idx = this.registeredToolbarButtons.indexOf(config);
+            if (idx >= 0) this.registeredToolbarButtons.splice(idx, 1);
+          },
+        };
+        this.disposables.push(disposable);
+        return disposable;
+      },
+
+      showNotification: (message: string, type: 'info' | 'warning' | 'error') => {
+        // 将来的には UI に通知コンポーネントを追加
+        const prefix = `[Plugin:${this.pluginId}]`;
+        switch (type) {
+          case 'error':
+            console.error(prefix, message);
+            break;
+          case 'warning':
+            console.warn(prefix, message);
+            break;
+          default:
+            console.info(prefix, message);
+        }
+      },
+    };
+  }
+
+  get settings(): PluginSettingsApi {
+    return {
+      get: <T>(key: string, defaultValue: T): T => {
+        this.requirePermission('settings:read');
+        const val = this.pluginSettings[key];
+        return val !== undefined ? (val as T) : defaultValue;
+      },
+
+      set: (key: string, value: unknown) => {
+        this.requirePermission('settings:write');
+        this.pluginSettings[key] = value;
+        const listeners = this.settingsListeners.get(key);
+        if (listeners) {
+          listeners.forEach((cb) => cb(value));
+        }
+      },
+
+      onChange: (key: string, callback: (value: unknown) => void): Disposable => {
+        this.requirePermission('settings:read');
+        if (!this.settingsListeners.has(key)) {
+          this.settingsListeners.set(key, new Set());
+        }
+        this.settingsListeners.get(key)!.add(callback);
+        const disposable = {
+          dispose: () => {
+            this.settingsListeners.get(key)?.delete(callback);
+          },
+        };
+        this.disposables.push(disposable);
+        return disposable;
+      },
+    };
+  }
+
+  get log(): PluginLogApi {
+    const prefix = `[Plugin:${this.pluginId}]`;
+    return {
+      info: (message: string) => console.info(prefix, message),
+      warn: (message: string) => console.warn(prefix, message),
+      error: (message: string) => console.error(prefix, message),
+    };
+  }
+
+  /** プラグイン設定を外部から注入（永続化復元時に使用） */
+  loadSettings(settings: Record<string, unknown>): void {
+    this.pluginSettings = { ...settings };
+  }
+
+  /** 現在の設定を取得（永続化時に使用） */
+  getSettings(): Record<string, unknown> {
+    return { ...this.pluginSettings };
+  }
+
+  /** 全 disposable を解除 */
+  disposeAll(): void {
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+    this.disposables = [];
+    this.registeredPanels.length = 0;
+    this.registeredToolbarButtons.length = 0;
+    this.frameRenderCallbacks.length = 0;
+    this.settingsListeners.clear();
+  }
+
+  private requirePermission(permission: PluginPermission): void {
+    if (!this.permissions.has(permission)) {
+      throw new PluginPermissionError(this.pluginId, permission);
+    }
+  }
+}

--- a/src/plugin-system/index.ts
+++ b/src/plugin-system/index.ts
@@ -1,0 +1,8 @@
+export { PluginManager } from './manager';
+export { PluginLoader } from './loader';
+export { PluginContextImpl, PluginPermissionError } from './context';
+export { WasmPluginWrapper } from './wasm-wrapper';
+
+export type { PluginManifest, PluginPermission, PluginType, PluginCategory } from './types/manifest';
+export type { PluginContext, Disposable, ClipChangeEvent, PanelConfig, ToolbarButtonConfig } from './types/api';
+export type { QcutPlugin, WasmExports } from './types/plugin';

--- a/src/plugin-system/loader.ts
+++ b/src/plugin-system/loader.ts
@@ -1,0 +1,141 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { PluginManifest, PluginPermission, PluginType, PluginCategory } from './types/manifest';
+import type { QcutPlugin } from './types/plugin';
+import { WasmPluginWrapper } from './wasm-wrapper';
+
+const VALID_PERMISSIONS: PluginPermission[] = [
+  'timeline:read', 'timeline:write',
+  'preview:read', 'preview:write',
+  'file:read', 'file:write',
+  'settings:read', 'settings:write',
+  'ui:panel', 'ui:toolbar',
+  'frame:process',
+];
+
+const VALID_TYPES: PluginType[] = ['typescript', 'wasm', 'hybrid'];
+const VALID_CATEGORIES: PluginCategory[] = ['effect', 'filter', 'export', 'import', 'ui', 'tool'];
+
+export class PluginLoader {
+  async discoverPlugins(): Promise<{ manifest: PluginManifest; dir: string }[]> {
+    const dirs = await invoke<string[]>('list_plugin_dirs');
+    const results: { manifest: PluginManifest; dir: string }[] = [];
+
+    for (const dir of dirs) {
+      try {
+        const raw = await invoke<string>('read_plugin_manifest', { pluginDir: dir });
+        const parsed: unknown = JSON.parse(raw);
+        const manifest = this.validateManifest(parsed);
+        if (manifest) {
+          results.push({ manifest, dir });
+        }
+      } catch (e) {
+        console.warn(`[PluginLoader] ${dir} のマニフェスト読み込みに失敗:`, e);
+      }
+    }
+
+    return results;
+  }
+
+  async loadTypeScriptPlugin(manifest: PluginManifest, pluginDir: string): Promise<QcutPlugin> {
+    if (!manifest.entry.js) {
+      throw new Error(`[${manifest.id}] TypeScript エントリポイントが未指定`);
+    }
+
+    const filePath = `${pluginDir}/${manifest.entry.js}`;
+    const bytes = await invoke<number[]>('read_plugin_file', { filePath });
+    const source = new TextDecoder().decode(new Uint8Array(bytes));
+    const blob = new Blob([source], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+
+    try {
+      const module = await import(/* @vite-ignore */ url);
+      const plugin: QcutPlugin = module.default;
+
+      if (!plugin || typeof plugin.onInit !== 'function') {
+        throw new Error(`[${manifest.id}] default export が QcutPlugin インターフェースを満たしていません`);
+      }
+
+      return plugin;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  async loadWasmPlugin(manifest: PluginManifest, pluginDir: string): Promise<WasmPluginWrapper> {
+    if (!manifest.entry.wasm) {
+      throw new Error(`[${manifest.id}] WASM エントリポイントが未指定`);
+    }
+
+    const filePath = `${pluginDir}/${manifest.entry.wasm}`;
+    const bytes = await invoke<number[]>('read_plugin_file', { filePath });
+    const buffer = new Uint8Array(bytes).buffer;
+
+    return new WasmPluginWrapper(buffer, manifest);
+  }
+
+  async loadPlugin(manifest: PluginManifest, pluginDir: string): Promise<QcutPlugin> {
+    switch (manifest.type) {
+      case 'typescript':
+        return this.loadTypeScriptPlugin(manifest, pluginDir);
+      case 'wasm':
+        return this.loadWasmPlugin(manifest, pluginDir);
+      case 'hybrid': {
+        const tsPlugin = await this.loadTypeScriptPlugin(manifest, pluginDir);
+        const wasmWrapper = await this.loadWasmPlugin(manifest, pluginDir);
+        // hybrid: TS プラグインが UI/ライフサイクルを担当し、WASM は processFrame として利用可能
+        (tsPlugin as QcutPlugin & { wasmProcessor?: WasmPluginWrapper }).wasmProcessor = wasmWrapper;
+        return tsPlugin;
+      }
+      default:
+        throw new Error(`[${manifest.id}] 未知のプラグインタイプ: ${manifest.type}`);
+    }
+  }
+
+  validateManifest(raw: unknown): PluginManifest | null {
+    if (!raw || typeof raw !== 'object') return null;
+
+    const obj = raw as Record<string, unknown>;
+
+    // 必須フィールドのチェック
+    if (typeof obj.id !== 'string' || !obj.id) return null;
+    if (typeof obj.name !== 'string' || !obj.name) return null;
+    if (typeof obj.version !== 'string') return null;
+    if (typeof obj.description !== 'string') return null;
+    if (typeof obj.author !== 'string') return null;
+    if (typeof obj.minAppVersion !== 'string') return null;
+
+    if (!VALID_TYPES.includes(obj.type as PluginType)) return null;
+    if (!VALID_CATEGORIES.includes(obj.category as PluginCategory)) return null;
+
+    // entry の検証
+    if (!obj.entry || typeof obj.entry !== 'object') return null;
+    const entry = obj.entry as Record<string, unknown>;
+    if (obj.type === 'typescript' && typeof entry.js !== 'string') return null;
+    if (obj.type === 'wasm' && typeof entry.wasm !== 'string') return null;
+    if (obj.type === 'hybrid') {
+      if (typeof entry.js !== 'string' || typeof entry.wasm !== 'string') return null;
+    }
+
+    // permissions の検証
+    if (!Array.isArray(obj.permissions)) return null;
+    const permissions = obj.permissions as string[];
+    if (!permissions.every((p) => VALID_PERMISSIONS.includes(p as PluginPermission))) return null;
+
+    return {
+      id: obj.id as string,
+      name: obj.name as string,
+      version: obj.version as string,
+      description: obj.description as string,
+      author: obj.author as string,
+      type: obj.type as PluginType,
+      entry: {
+        js: typeof entry.js === 'string' ? entry.js : undefined,
+        wasm: typeof entry.wasm === 'string' ? entry.wasm : undefined,
+      },
+      permissions: permissions as PluginPermission[],
+      minAppVersion: obj.minAppVersion as string,
+      category: obj.category as PluginCategory,
+      settingsSchema: typeof obj.settingsSchema === 'object' ? obj.settingsSchema as Record<string, unknown> : undefined,
+    };
+  }
+}

--- a/src/plugin-system/manager.ts
+++ b/src/plugin-system/manager.ts
@@ -1,0 +1,198 @@
+import { invoke } from '@tauri-apps/api/core';
+import { usePluginStore } from '@/store/pluginStore';
+import { PluginLoader } from './loader';
+import { PluginContextImpl } from './context';
+import type { QcutPlugin } from './types/plugin';
+
+interface PluginSettingsEntry {
+  enabled: boolean;
+  settings: Record<string, unknown>;
+}
+
+type PersistedSettings = Record<string, PluginSettingsEntry>;
+
+export class PluginManager {
+  private loader = new PluginLoader();
+  private contexts = new Map<string, PluginContextImpl>();
+  private pluginDirs = new Map<string, string>();
+  private instances = new Map<string, QcutPlugin>();
+
+  async initialize(): Promise<void> {
+
+    const persisted = await this.loadPersistedSettings();
+    const discovered = await this.loader.discoverPlugins();
+
+    const store = usePluginStore.getState();
+
+    for (const { manifest, dir } of discovered) {
+      const isEnabled = persisted[manifest.id]?.enabled ?? true;
+      store.registerPlugin(manifest, isEnabled);
+      this.pluginDirs.set(manifest.id, dir);
+
+      if (isEnabled) {
+        await this.activatePlugin(manifest.id);
+      }
+    }
+  }
+
+  async activatePlugin(id: string): Promise<void> {
+    const store = usePluginStore.getState();
+    const entry = store.plugins[id];
+    if (!entry) return;
+
+    const dir = this.pluginDirs.get(id);
+    if (!dir) return;
+
+    await this.safeCall(id, async () => {
+      // Load
+      store.setPluginState(id, 'loaded');
+      const instance = await this.loader.loadPlugin(entry.manifest, dir);
+      this.instances.set(id, instance);
+      store.setPluginInstance(id, instance);
+
+      // Create context
+      const context = new PluginContextImpl(id, entry.manifest);
+      this.contexts.set(id, context);
+
+      // Restore settings
+      const persisted = await this.loadPersistedSettings();
+      if (persisted[id]?.settings) {
+        context.loadSettings(persisted[id].settings);
+      }
+
+      // Initialize
+      store.setPluginState(id, 'initialized');
+      await instance.onInit(context);
+
+      // Activate
+      await instance.onActivate();
+      store.setPluginState(id, 'active');
+    });
+  }
+
+  async deactivatePlugin(id: string): Promise<void> {
+    const store = usePluginStore.getState();
+    const instance = this.instances.get(id);
+    const context = this.contexts.get(id);
+
+    if (instance) {
+      await this.safeCall(id, async () => {
+        await instance.onDeactivate();
+      });
+    }
+
+    if (context) {
+      await this.persistPluginSettings(id, context.getSettings());
+      context.disposeAll();
+      this.contexts.delete(id);
+    }
+
+    this.instances.delete(id);
+    store.setPluginState(id, 'inactive');
+  }
+
+  async togglePlugin(id: string, enabled: boolean): Promise<void> {
+    const store = usePluginStore.getState();
+    store.togglePlugin(id, enabled);
+
+    if (enabled) {
+      await this.activatePlugin(id);
+    } else {
+      await this.deactivatePlugin(id);
+    }
+
+    await this.persistEnabledState(id, enabled);
+  }
+
+  async shutdown(): Promise<void> {
+    const ids = [...this.instances.keys()];
+    for (const id of ids) {
+      const instance = this.instances.get(id);
+      const context = this.contexts.get(id);
+
+      if (instance) {
+        await this.safeCall(id, async () => {
+          await instance.onDeactivate();
+          if (instance.onDestroy) {
+            await instance.onDestroy();
+          }
+        });
+      }
+
+      if (context) {
+        await this.persistPluginSettings(id, context.getSettings());
+        context.disposeAll();
+      }
+    }
+
+    this.instances.clear();
+    this.contexts.clear();
+  }
+
+  getContext(id: string): PluginContextImpl | undefined {
+    return this.contexts.get(id);
+  }
+
+  private async safeCall<T>(pluginId: string, fn: () => Promise<T>): Promise<T | null> {
+    try {
+      return await fn();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[Plugin ${pluginId}] Error:`, message);
+
+      usePluginStore.getState().setPluginState(pluginId, 'error', message);
+
+      const context = this.contexts.get(pluginId);
+      if (context) {
+        context.disposeAll();
+        this.contexts.delete(pluginId);
+      }
+
+      this.instances.delete(pluginId);
+
+      return null;
+    }
+  }
+
+  private async loadPersistedSettings(): Promise<PersistedSettings> {
+    try {
+      const json = await invoke<string>('read_plugin_settings');
+      return JSON.parse(json) as PersistedSettings;
+    } catch {
+      return {};
+    }
+  }
+
+  private async persistEnabledState(id: string, enabled: boolean): Promise<void> {
+    const settings = await this.loadPersistedSettings();
+    if (!settings[id]) {
+      settings[id] = { enabled, settings: {} };
+    } else {
+      settings[id].enabled = enabled;
+    }
+    await this.savePersistedSettings(settings);
+  }
+
+  private async persistPluginSettings(
+    id: string,
+    pluginSettings: Record<string, unknown>,
+  ): Promise<void> {
+    const settings = await this.loadPersistedSettings();
+    if (!settings[id]) {
+      settings[id] = { enabled: true, settings: pluginSettings };
+    } else {
+      settings[id].settings = pluginSettings;
+    }
+    await this.savePersistedSettings(settings);
+  }
+
+  private async savePersistedSettings(settings: PersistedSettings): Promise<void> {
+    try {
+      await invoke('write_plugin_settings', {
+        content: JSON.stringify(settings, null, 2),
+      });
+    } catch (e) {
+      console.warn('[PluginManager] 設定の保存に失敗:', e);
+    }
+  }
+}

--- a/src/plugin-system/types/api.ts
+++ b/src/plugin-system/types/api.ts
@@ -1,0 +1,71 @@
+import type { Clip, Track } from '@/store/timelineStore';
+import type { PluginManifest } from './manifest';
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export interface ClipChangeEvent {
+  type: 'added' | 'removed' | 'updated';
+  trackId: string;
+  clipId: string;
+  clip?: Clip;
+}
+
+export interface PanelConfig {
+  id: string;
+  title: string;
+  location: 'sidebar' | 'bottom' | 'floating';
+  render: (container: HTMLElement) => void | (() => void);
+}
+
+export interface ToolbarButtonConfig {
+  id: string;
+  label: string;
+  icon?: string;
+  onClick: () => void;
+}
+
+export interface PluginTimelineApi {
+  getTracks(): readonly Track[];
+  getClipById(clipId: string): Clip | null;
+  getCurrentTime(): number;
+  onTimeChange(callback: (time: number) => void): Disposable;
+  onClipChange(callback: (event: ClipChangeEvent) => void): Disposable;
+  addClip(trackId: string, clip: Omit<Clip, 'id'>): string;
+  updateClip(trackId: string, clipId: string, updates: Partial<Clip>): void;
+  removeClip(trackId: string, clipId: string): void;
+}
+
+export interface PluginPreviewApi {
+  getCurrentFrameData(): ImageData | null;
+  onFrameRender(callback: (frame: ImageData) => ImageData): Disposable;
+}
+
+export interface PluginUiApi {
+  registerPanel(config: PanelConfig): Disposable;
+  registerToolbarButton(config: ToolbarButtonConfig): Disposable;
+  showNotification(message: string, type: 'info' | 'warning' | 'error'): void;
+}
+
+export interface PluginSettingsApi {
+  get<T>(key: string, defaultValue: T): T;
+  set(key: string, value: unknown): void;
+  onChange(key: string, callback: (value: unknown) => void): Disposable;
+}
+
+export interface PluginLogApi {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+export interface PluginContext {
+  readonly pluginId: string;
+  readonly manifest: Readonly<PluginManifest>;
+  readonly timeline: PluginTimelineApi;
+  readonly preview: PluginPreviewApi;
+  readonly ui: PluginUiApi;
+  readonly settings: PluginSettingsApi;
+  readonly log: PluginLogApi;
+}

--- a/src/plugin-system/types/manifest.ts
+++ b/src/plugin-system/types/manifest.ts
@@ -1,0 +1,33 @@
+export type PluginPermission =
+  | 'timeline:read'
+  | 'timeline:write'
+  | 'preview:read'
+  | 'preview:write'
+  | 'file:read'
+  | 'file:write'
+  | 'settings:read'
+  | 'settings:write'
+  | 'ui:panel'
+  | 'ui:toolbar'
+  | 'frame:process';
+
+export type PluginType = 'typescript' | 'wasm' | 'hybrid';
+
+export type PluginCategory = 'effect' | 'filter' | 'export' | 'import' | 'ui' | 'tool';
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  type: PluginType;
+  entry: {
+    js?: string;
+    wasm?: string;
+  };
+  permissions: PluginPermission[];
+  minAppVersion: string;
+  category: PluginCategory;
+  settingsSchema?: Record<string, unknown>;
+}

--- a/src/plugin-system/types/plugin.ts
+++ b/src/plugin-system/types/plugin.ts
@@ -1,0 +1,17 @@
+import type { PluginContext } from './api';
+
+export interface QcutPlugin {
+  onInit(context: PluginContext): Promise<void> | void;
+  onActivate(): Promise<void> | void;
+  onDeactivate(): Promise<void> | void;
+  onDestroy?(): Promise<void> | void;
+}
+
+export interface WasmExports {
+  memory: WebAssembly.Memory;
+  alloc(size: number): number;
+  dealloc(ptr: number, size: number): void;
+  process_frame(input: number, width: number, height: number, output: number): void;
+  activate?(): void;
+  deactivate?(): void;
+}

--- a/src/plugin-system/wasm-wrapper.ts
+++ b/src/plugin-system/wasm-wrapper.ts
@@ -1,0 +1,102 @@
+import type { PluginManifest } from './types/manifest';
+import type { PluginContext } from './types/api';
+import type { QcutPlugin, WasmExports } from './types/plugin';
+
+export class WasmPluginWrapper implements QcutPlugin {
+  private instance: WebAssembly.Instance | null = null;
+  private memory: WebAssembly.Memory | null = null;
+  private context: PluginContext | null = null;
+
+  constructor(
+    private wasmBytes: ArrayBuffer,
+    private manifest: PluginManifest,
+  ) {}
+
+  async onInit(context: PluginContext): Promise<void> {
+    this.context = context;
+
+    const textDecoder = new TextDecoder();
+
+    const importObject = {
+      env: {
+        log_info: (ptr: number, len: number) => {
+          const msg = this.readString(ptr, len, textDecoder);
+          context.log.info(msg);
+        },
+        log_warn: (ptr: number, len: number) => {
+          const msg = this.readString(ptr, len, textDecoder);
+          context.log.warn(msg);
+        },
+        log_error: (ptr: number, len: number) => {
+          const msg = this.readString(ptr, len, textDecoder);
+          context.log.error(msg);
+        },
+      },
+    };
+
+    const result = await WebAssembly.instantiate(this.wasmBytes, importObject);
+    this.instance = result.instance;
+    this.memory = result.instance.exports.memory as WebAssembly.Memory;
+  }
+
+  onActivate(): void {
+    const exports = this.getExports();
+    if (exports.activate) {
+      exports.activate();
+    }
+  }
+
+  onDeactivate(): void {
+    const exports = this.getExports();
+    if (exports.deactivate) {
+      exports.deactivate();
+    }
+  }
+
+  onDestroy(): void {
+    this.instance = null;
+    this.memory = null;
+    this.context = null;
+  }
+
+  processFrame(imageData: ImageData): ImageData {
+    const exports = this.getExports();
+    const inputSize = imageData.data.byteLength;
+
+    const inputPtr = exports.alloc(inputSize);
+    const outputPtr = exports.alloc(inputSize);
+
+    try {
+      const memView = new Uint8Array(exports.memory.buffer);
+      memView.set(imageData.data, inputPtr);
+
+      exports.process_frame(inputPtr, imageData.width, imageData.height, outputPtr);
+
+      const outputData = new Uint8ClampedArray(
+        exports.memory.buffer.slice(outputPtr, outputPtr + inputSize),
+      );
+
+      return new ImageData(outputData, imageData.width, imageData.height);
+    } finally {
+      exports.dealloc(inputPtr, inputSize);
+      exports.dealloc(outputPtr, inputSize);
+    }
+  }
+
+  get pluginManifest(): PluginManifest {
+    return this.manifest;
+  }
+
+  private getExports(): WasmExports {
+    if (!this.instance) {
+      throw new Error(`[${this.manifest.id}] WASM が初期化されていません`);
+    }
+    return this.instance.exports as unknown as WasmExports;
+  }
+
+  private readString(ptr: number, len: number, decoder: TextDecoder): string {
+    if (!this.memory) return '';
+    const bytes = new Uint8Array(this.memory.buffer, ptr, len);
+    return decoder.decode(bytes);
+  }
+}

--- a/src/store/pluginStore.ts
+++ b/src/store/pluginStore.ts
@@ -1,0 +1,92 @@
+import { create } from 'zustand';
+import type { PluginManifest } from '@/plugin-system/types/manifest';
+import type { QcutPlugin } from '@/plugin-system/types/plugin';
+
+export type PluginState =
+  | 'installed'
+  | 'loaded'
+  | 'initialized'
+  | 'active'
+  | 'inactive'
+  | 'error';
+
+export interface PluginEntry {
+  manifest: PluginManifest;
+  state: PluginState;
+  enabled: boolean;
+  error?: string;
+  instance?: QcutPlugin;
+}
+
+interface PluginStoreState {
+  plugins: Record<string, PluginEntry>;
+
+  registerPlugin: (manifest: PluginManifest, enabled?: boolean) => void;
+  setPluginState: (id: string, state: PluginState, error?: string) => void;
+  setPluginInstance: (id: string, instance: QcutPlugin) => void;
+  togglePlugin: (id: string, enabled: boolean) => void;
+  removePlugin: (id: string) => void;
+}
+
+export const usePluginStore = create<PluginStoreState>((set) => ({
+  plugins: {},
+
+  registerPlugin: (manifest, enabled = true) =>
+    set((state) => ({
+      plugins: {
+        ...state.plugins,
+        [manifest.id]: {
+          manifest,
+          state: 'installed',
+          enabled,
+        },
+      },
+    })),
+
+  setPluginState: (id, pluginState, error) =>
+    set((state) => {
+      const entry = state.plugins[id];
+      if (!entry) return state;
+      return {
+        plugins: {
+          ...state.plugins,
+          [id]: {
+            ...entry,
+            state: pluginState,
+            error: error ?? entry.error,
+          },
+        },
+      };
+    }),
+
+  setPluginInstance: (id, instance) =>
+    set((state) => {
+      const entry = state.plugins[id];
+      if (!entry) return state;
+      return {
+        plugins: {
+          ...state.plugins,
+          [id]: { ...entry, instance },
+        },
+      };
+    }),
+
+  togglePlugin: (id, enabled) =>
+    set((state) => {
+      const entry = state.plugins[id];
+      if (!entry) return state;
+      return {
+        plugins: {
+          ...state.plugins,
+          [id]: { ...entry, enabled },
+        },
+      };
+    }),
+
+  removePlugin: (id) =>
+    set((state) => {
+      const { [id]: _removed, ...rest } = state.plugins;
+      void _removed;
+      return { plugins: rest };
+    }),
+}));


### PR DESCRIPTION
## Summary
- TypeScript / WASM / hybrid の3種類のプラグインをサポートするプラグインシステムを導入
- プラグインのライフサイクル管理（検出→読み込み→初期化→有効化⇄無効化）、権限ベースのAPI制御、エラー隔離を実装
- Rust側にプラグインディレクトリ走査・ファイル読み込み・設定永続化のTauriコマンドを追加

## 新規ファイル
### フロントエンド (`src/plugin-system/`)
- `types/manifest.ts` — マニフェスト・権限の型定義
- `types/api.ts` — PluginContext APIインターフェース
- `types/plugin.ts` — QcutPlugin / WasmExportsインターフェース
- `loader.ts` — プラグイン検出・TS(Blob URL import)/WASM(WebAssembly.instantiate)読み込み
- `wasm-wrapper.ts` — WASM→QcutPluginアダプタ（RGBAフレーム処理対応）
- `context.ts` — 権限チェック付きAPI実装（Zustandストア連携）
- `manager.ts` — ライフサイクル管理・設定永続化
- `index.ts` — barrel export
- `src/store/pluginStore.ts` — Zustandストア

### バックエンド (`src-tauri/`)
- `commands/plugins.rs` — 5つのTauriコマンド（list_plugin_dirs, read_plugin_manifest, read_plugin_file, read_plugin_settings, write_plugin_settings）

### ドキュメント
- `README.md` にアーキテクチャ図、プラグインの作り方、APIリファレンス、権限一覧を追加

## Test plan
- [x] `npm run lint` パス
- [x] `npm run test` 全25テストパス
- [x] `npm run build` 成功
- [ ] Tauri環境でプラグインディレクトリ作成・検出の動作確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)