### PR TITLE
基本エフェクト機能の実装（明るさ・コントラスト・彩度）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,10 +53,11 @@
 .preview-container {
   flex: 1;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: row;
+  align-items: stretch;
   background-color: #000;
-  overflow: auto;
+  overflow: hidden;
+  min-height: 0;
 }
 
 .timeline-container {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import './App.css';
 import Timeline from './components/Timeline/Timeline';
 import { VideoPreview } from './components/VideoPreview/VideoPreview';
+import { EffectsPanel } from './components/Inspector/EffectsPanel';
 import { FileOperations } from './components/FileOperations/FileOperations';
 import { useTimelineStore } from './store/timelineStore';
 import { useVideoPreviewStore } from './store/videoPreviewStore';
@@ -84,6 +85,7 @@ function App() {
       <main className="app-main">
         <div className="preview-container">
           <VideoPreview />
+          <EffectsPanel />
         </div>
         <div className="timeline-container">
           <Timeline />

--- a/src/components/Inspector/EffectsPanel.tsx
+++ b/src/components/Inspector/EffectsPanel.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTimelineStore, DEFAULT_EFFECTS } from '../../store/timelineStore';
+import type { ClipEffects } from '../../store/timelineStore';
+
+interface EffectSliderProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const EffectSlider: React.FC<EffectSliderProps> = ({ label, value, onChange }) => {
+  return (
+    <div style={{ marginBottom: '12px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+        <span style={{ fontSize: '12px', color: '#ccc' }}>{label}</span>
+        <span style={{ fontSize: '12px', color: '#999' }}>{value.toFixed(2)}</span>
+      </div>
+      <input
+        type="range"
+        min="0"
+        max="2"
+        step="0.01"
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        style={{ width: '100%', cursor: 'pointer' }}
+      />
+    </div>
+  );
+};
+
+export const EffectsPanel: React.FC = () => {
+  const { t } = useTranslation();
+  const selectedClipId = useTimelineStore((s) => s.selectedClipId);
+  const selectedTrackId = useTimelineStore((s) => s.selectedTrackId);
+  const tracks = useTimelineStore((s) => s.tracks);
+  const updateClip = useTimelineStore((s) => s.updateClip);
+
+  const selectedClip = useMemo(() => {
+    if (!selectedClipId || !selectedTrackId) return null;
+    const track = tracks.find((t) => t.id === selectedTrackId);
+    return track?.clips.find((c) => c.id === selectedClipId) ?? null;
+  }, [selectedClipId, selectedTrackId, tracks]);
+
+  const effects: ClipEffects = useMemo(() => {
+    return selectedClip?.effects ?? DEFAULT_EFFECTS;
+  }, [selectedClip?.effects]);
+
+  const handleChange = useCallback(
+    (key: keyof ClipEffects, value: number) => {
+      if (!selectedTrackId || !selectedClipId) return;
+      updateClip(selectedTrackId, selectedClipId, {
+        effects: { ...effects, [key]: value },
+      });
+    },
+    [selectedTrackId, selectedClipId, effects, updateClip],
+  );
+
+  const handleReset = useCallback(() => {
+    if (!selectedTrackId || !selectedClipId) return;
+    updateClip(selectedTrackId, selectedClipId, {
+      effects: { ...DEFAULT_EFFECTS },
+    });
+  }, [selectedTrackId, selectedClipId, updateClip]);
+
+  return (
+    <div
+      style={{
+        width: '220px',
+        minWidth: '220px',
+        padding: '12px',
+        backgroundColor: '#2a2a2a',
+        borderLeft: '1px solid #3a3a3a',
+        overflowY: 'auto',
+      }}
+    >
+      <h3 style={{ margin: '0 0 12px 0', fontSize: '14px', color: '#fff' }}>
+        {t('effects.title')}
+      </h3>
+
+      {!selectedClip ? (
+        <p style={{ fontSize: '12px', color: '#888' }}>
+          {t('effects.noClipSelected')}
+        </p>
+      ) : (
+        <>
+          <EffectSlider
+            label={t('effects.brightness')}
+            value={effects.brightness}
+            onChange={(v) => handleChange('brightness', v)}
+          />
+          <EffectSlider
+            label={t('effects.contrast')}
+            value={effects.contrast}
+            onChange={(v) => handleChange('contrast', v)}
+          />
+          <EffectSlider
+            label={t('effects.saturation')}
+            value={effects.saturation}
+            onChange={(v) => handleChange('saturation', v)}
+          />
+          <button
+            onClick={handleReset}
+            style={{
+              width: '100%',
+              padding: '6px',
+              fontSize: '12px',
+              backgroundColor: '#3a3a3a',
+              color: '#ccc',
+              border: '1px solid #555',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              marginTop: '8px',
+            }}
+          >
+            {t('effects.reset')}
+          </button>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -101,6 +101,7 @@ function Clip({ clip, trackId }: ClipProps) {
           backgroundColor: clip.color || '#4a9eff',
         }}
         onMouseDown={handleMouseDown}
+        onClick={(e) => e.stopPropagation()}
         onContextMenu={handleContextMenu}
         title={clip.name}
       >

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -107,12 +107,15 @@ function Timeline() {
     if (e.target === e.currentTarget || (e.target as HTMLElement).closest('.timeline-tracks')) {
       setSelectedClip(null, null);
     }
-    
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left + e.currentTarget.scrollLeft;
-    const time = x / pixelsPerSecond;
-    setCurrentTime(time);
-    videoPreviewStore.setCurrentTime(time);
+
+    // ルーラー領域のクリックのみシーク（トラック領域ではシークしない）
+    if ((e.target as HTMLElement).closest('.timeline-ruler')) {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left + e.currentTarget.scrollLeft;
+      const time = x / pixelsPerSecond;
+      setCurrentTime(time);
+      videoPreviewStore.setCurrentTime(time);
+    }
   };
 
   const handleTracksScroll = (e: React.UIEvent<HTMLDivElement>) => {

--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -328,6 +328,13 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
     return currentClip !== null && currentVideoUrl !== null;
   }, [currentClip, currentVideoUrl]);
 
+  // エフェクトから CSS filter 文字列を生成
+  const cssFilter = useMemo(() => {
+    if (!currentClip?.effects) return 'none';
+    const e = currentClip.effects;
+    return `brightness(${e.brightness}) contrast(${e.contrast}) saturate(${e.saturation})`;
+  }, [currentClip?.effects]);
+
   // 動画ファイルが切り替わったとき src を更新してシーク（停止中のみ）
   useEffect(() => {
     if (!videoRef.current) return;
@@ -423,17 +430,17 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
       style={{
         width,
         height,
+        flex: 1,
+        minWidth: 0,
         display: 'flex',
         flexDirection: 'column',
         gap: '12px',
         padding: '12px',
-        border: '1px solid #ccc',
-        borderRadius: '4px',
-        backgroundColor: '#f9f9f9',
+        backgroundColor: '#1a1a1a',
       }}
     >
       {/* ビデオプレイヤー（常にDOMに存在させ、ギャップ中に消えないようにする） */}
-      <div style={{ position: 'relative', width: '100%', height: '300px' }}>
+      <div style={{ position: 'relative', width: '100%', flex: 1, minHeight: 0 }}>
         <video
           ref={videoRef}
           onLoadedMetadata={handleMetadata}
@@ -443,6 +450,7 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
             backgroundColor: '#000',
             borderRadius: '4px',
             visibility: hasCurrentClip ? 'visible' : 'hidden',
+            filter: cssFilter,
           }}
         />
         {!hasCurrentClip && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,6 +31,14 @@
       "time": "Time"
     }
   },
+  "effects": {
+    "title": "Effects",
+    "noClipSelected": "Select a clip",
+    "brightness": "Brightness",
+    "contrast": "Contrast",
+    "saturation": "Saturation",
+    "reset": "Reset"
+  },
   "timeline": {
     "title": "Timeline",
     "videoTracks": "Video Tracks",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -31,6 +31,14 @@
       "time": "時間"
     }
   },
+  "effects": {
+    "title": "エフェクト",
+    "noClipSelected": "クリップを選択してください",
+    "brightness": "明るさ",
+    "contrast": "コントラスト",
+    "saturation": "彩度",
+    "reset": "リセット"
+  },
   "timeline": {
     "title": "タイムライン",
     "videoTracks": "ビデオトラック",

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -1,16 +1,31 @@
 import { create } from 'zustand';
 
+export interface ClipEffects {
+  brightness: number; // 0〜2, default 1.0
+  contrast: number;   // 0〜2, default 1.0
+  saturation: number; // 0〜2, default 1.0
+}
+
+export const DEFAULT_EFFECTS: ClipEffects = {
+  brightness: 1.0,
+  contrast: 1.0,
+  saturation: 1.0,
+};
+
 export interface Clip {
   id: string;
   name: string;
   startTime: number; // タイムライン上の開始位置（秒）
   duration: number; // タイムライン上の表示時間（秒）
   color?: string;
-  
+
   // 動画ファイル情報
   filePath: string; // 動画ファイルのパス
   sourceStartTime: number; // 元動画の開始位置（秒）
   sourceEndTime: number; // 元動画の終了位置（秒）
+
+  // エフェクト
+  effects?: ClipEffects;
 }
 
 export interface Track {


### PR DESCRIPTION
## Summary
- クリップに対して明るさ・コントラスト・彩度のエフェクトを適用できるようにした
- CSS `filter` を `<video>` 要素に直接適用するシンプルなアプローチ
- エフェクト編集用の Inspector パネル（EffectsPanel）を新規追加
- タイムラインのクリップ選択がシークに奪われるバグも修正

## 変更内容
- `ClipEffects` 型・`DEFAULT_EFFECTS` を `timelineStore` に追加（`Clip.effects?`）
- `VideoPreview` で `currentClip.effects` → CSS filter 文字列を生成し適用
- `EffectsPanel` コンポーネント新規作成（スライダー3本 + リセットボタン）
- App レイアウトを preview + inspector 横並びに変更
- タイムラインのシークをルーラー領域クリックのみに限定
- クリップの `click` イベント伝播を防止し選択維持

## Test plan
- [x] クリップを選択し、EffectsPanel のスライダーで明るさ・コントラスト・彩度を変更 → プレビューに反映されること
- [x] リセットボタンでデフォルト値（全て1.0）に戻ること
- [x] クリップ分割時にエフェクト設定が両方のクリップに引き継がれること
- [x] タイムラインのトラック領域クリックでクリップ選択が解除されないこと（ルーラーのみシーク）
- [x] `npm run lint` / `npm run test` / `npm run build` パス

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)