### PR TITLE
クリップ右クリック時にプレイヘッドを移動

### DIFF
--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -1,4 +1,5 @@
 import { useTimelineStore, Clip as ClipType } from '../../store/timelineStore';
+import { useVideoPreviewStore } from '../../store/videoPreviewStore';
 import { useState, useRef, useEffect } from 'react';
 
 interface ClipProps {
@@ -70,6 +71,18 @@ function Clip({ clip, trackId }: ClipProps) {
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    // 右クリック位置にプレイヘッドを移動
+    const clipEl = (e.currentTarget as HTMLElement).closest('.timeline-clip');
+    if (clipEl) {
+      const rect = clipEl.getBoundingClientRect();
+      const relX = e.clientX - rect.left;
+      const relTime = relX / pixelsPerSecond;
+      const time = clip.startTime + Math.max(0, Math.min(relTime, clip.duration));
+      useTimelineStore.getState().setCurrentTime(time);
+      useVideoPreviewStore.getState().setCurrentTime(time);
+    }
+
     setContextMenuPos({ x: e.clientX, y: e.clientY });
     setShowContextMenu(true);
     setSelectedClip(trackId, clip.id);


### PR DESCRIPTION
## Summary
- クリップを右クリックした際、クリック位置にプレイヘッドを移動するようにした
- 分割操作が右クリックした位置で正確に行えるようになる

## Test plan
- [x] クリップ上で右クリック → プレイヘッドがクリック位置に移動すること
- [x] コンテキストメニューから「分割」→ 右クリックした位置で分割されること
- [x] `npm run lint` / `npm run test` / `npm run build` パス

