### PR TITLE
トランスフォーム機能の実装（回転・スケール・位置）

### DIFF
--- a/src/components/Inspector/EffectsPanel.tsx
+++ b/src/components/Inspector/EffectsPanel.tsx
@@ -7,9 +7,12 @@ interface EffectSliderProps {
   label: string;
   value: number;
   onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
 }
 
-const EffectSlider: React.FC<EffectSliderProps> = ({ label, value, onChange }) => {
+const EffectSlider: React.FC<EffectSliderProps> = ({ label, value, onChange, min = 0, max = 2, step = 0.01 }) => {
   return (
     <div style={{ marginBottom: '12px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
@@ -18,9 +21,9 @@ const EffectSlider: React.FC<EffectSliderProps> = ({ label, value, onChange }) =
       </div>
       <input
         type="range"
-        min="0"
-        max="2"
-        step="0.01"
+        min={min}
+        max={max}
+        step={step}
         value={value}
         onChange={(e) => onChange(parseFloat(e.target.value))}
         style={{ width: '100%', cursor: 'pointer' }}
@@ -99,6 +102,51 @@ export const EffectsPanel: React.FC = () => {
             value={effects.saturation}
             onChange={(v) => handleChange('saturation', v)}
           />
+
+          <h4 style={{ margin: '16px 0 8px 0', fontSize: '13px', color: '#ddd', borderTop: '1px solid #3a3a3a', paddingTop: '12px' }}>
+            {t('transform.title')}
+          </h4>
+          <EffectSlider
+            label={t('transform.rotation')}
+            value={effects.rotation}
+            onChange={(v) => handleChange('rotation', v)}
+            min={-180}
+            max={180}
+            step={1}
+          />
+          <EffectSlider
+            label={t('transform.scaleX')}
+            value={effects.scaleX}
+            onChange={(v) => handleChange('scaleX', v)}
+            min={0.1}
+            max={3}
+            step={0.01}
+          />
+          <EffectSlider
+            label={t('transform.scaleY')}
+            value={effects.scaleY}
+            onChange={(v) => handleChange('scaleY', v)}
+            min={0.1}
+            max={3}
+            step={0.01}
+          />
+          <EffectSlider
+            label={t('transform.positionX')}
+            value={effects.positionX}
+            onChange={(v) => handleChange('positionX', v)}
+            min={-500}
+            max={500}
+            step={1}
+          />
+          <EffectSlider
+            label={t('transform.positionY')}
+            value={effects.positionY}
+            onChange={(v) => handleChange('positionY', v)}
+            min={-500}
+            max={500}
+            step={1}
+          />
+
           <button
             onClick={handleReset}
             style={{

--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -335,6 +335,19 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
     return `brightness(${e.brightness}) contrast(${e.contrast}) saturate(${e.saturation})`;
   }, [currentClip?.effects]);
 
+  // トランスフォームから CSS transform 文字列を生成
+  const cssTransform = useMemo(() => {
+    if (!currentClip?.effects) return 'none';
+    const e = currentClip.effects;
+    const r = e.rotation ?? 0;
+    const sx = e.scaleX ?? 1;
+    const sy = e.scaleY ?? 1;
+    const px = e.positionX ?? 0;
+    const py = e.positionY ?? 0;
+    if (r === 0 && sx === 1 && sy === 1 && px === 0 && py === 0) return 'none';
+    return `translate(${px}px, ${py}px) rotate(${r}deg) scaleX(${sx}) scaleY(${sy})`;
+  }, [currentClip?.effects]);
+
   // 動画ファイルが切り替わったとき src を更新してシーク（停止中のみ）
   useEffect(() => {
     if (!videoRef.current) return;
@@ -440,7 +453,7 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
       }}
     >
       {/* ビデオプレイヤー（常にDOMに存在させ、ギャップ中に消えないようにする） */}
-      <div style={{ position: 'relative', width: '100%', flex: 1, minHeight: 0 }}>
+      <div style={{ position: 'relative', width: '100%', flex: 1, minHeight: 0, overflow: 'hidden' }}>
         <video
           ref={videoRef}
           onLoadedMetadata={handleMetadata}
@@ -451,6 +464,8 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
             borderRadius: '4px',
             visibility: hasCurrentClip ? 'visible' : 'hidden',
             filter: cssFilter,
+            transform: cssTransform,
+            transformOrigin: 'center center',
           }}
         />
         {!hasCurrentClip && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,6 +39,14 @@
     "saturation": "Saturation",
     "reset": "Reset"
   },
+  "transform": {
+    "title": "Transform",
+    "rotation": "Rotation",
+    "scaleX": "Scale X",
+    "scaleY": "Scale Y",
+    "positionX": "Position X",
+    "positionY": "Position Y"
+  },
   "timeline": {
     "title": "Timeline",
     "videoTracks": "Video Tracks",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -39,6 +39,14 @@
     "saturation": "彩度",
     "reset": "リセット"
   },
+  "transform": {
+    "title": "トランスフォーム",
+    "rotation": "回転",
+    "scaleX": "スケールX",
+    "scaleY": "スケールY",
+    "positionX": "位置X",
+    "positionY": "位置Y"
+  },
   "timeline": {
     "title": "タイムライン",
     "videoTracks": "ビデオトラック",

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -1,15 +1,25 @@
 import { create } from 'zustand';
 
 export interface ClipEffects {
-  brightness: number; // 0〜2, default 1.0
-  contrast: number;   // 0〜2, default 1.0
-  saturation: number; // 0〜2, default 1.0
+  brightness: number;  // 0〜2, default 1.0
+  contrast: number;    // 0〜2, default 1.0
+  saturation: number;  // 0〜2, default 1.0
+  rotation: number;    // -180〜180, default 0
+  scaleX: number;      // 0.1〜3, default 1.0
+  scaleY: number;      // 0.1〜3, default 1.0
+  positionX: number;   // -500〜500, default 0
+  positionY: number;   // -500〜500, default 0
 }
 
 export const DEFAULT_EFFECTS: ClipEffects = {
   brightness: 1.0,
   contrast: 1.0,
   saturation: 1.0,
+  rotation: 0,
+  scaleX: 1.0,
+  scaleY: 1.0,
+  positionX: 0,
+  positionY: 0,
 };
 
 export interface Clip {


### PR DESCRIPTION
## Summary
- クリップにトランスフォーム機能（回転・スケール・位置調整）を追加
- CSS transformで`<video>`要素に適用（既存のCSS filterと共存）
- EffectsPanelにトランスフォームセクションを追加

## 変更内容
- `ClipEffects`に`rotation`, `scaleX`, `scaleY`, `positionX`, `positionY`を追加
- `VideoPreview`に`cssTransform` useMemo追加、`<video>`にtransform適用
- `EffectSlider`を汎用化（min/max/step対応）
- i18n翻訳追加（日本語・英語）

Closes #26