### PR TITLE
ドキュメントのみの変更時にCIをスキップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- ci.ymlに`paths-ignore`を追加し、ドキュメントのみの変更時にCIジョブをスキップ
- 対象: `*.md`, `docs/**`, `LICENSE`

## Test plan
- [x] ドキュメントのみのPRでCIが実行されないこと
- [x] ソースコードを含むPRでは通常通りCIが実行されること