### PR TITLE
トランジション: データモデル・ストア拡張

### DIFF
--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -56,6 +56,19 @@ export const DEFAULT_TEXT_PROPERTIES: TextProperties = {
   animationDuration: 0.3,
 };
 
+export type TransitionType =
+  | 'crossfade'
+  | 'wipe-left'
+  | 'wipe-right'
+  | 'wipe-up'
+  | 'wipe-down'
+  | 'dissolve';
+
+export interface ClipTransition {
+  type: TransitionType;
+  duration: number; // オーバーラップ秒数（前クリップの末尾と当クリップの先頭が重なる）
+}
+
 export interface Clip {
   id: string;
   name: string;
@@ -73,6 +86,9 @@ export interface Clip {
 
   // テキストオーバーレイ
   textProperties?: TextProperties;
+
+  // トランジション（前のクリップとの境界に適用）
+  transition?: ClipTransition;
 }
 
 export interface Track {
@@ -108,6 +124,10 @@ export interface TimelineState {
   zoomIn: () => void;
   zoomOut: () => void;
   
+  // トランジション
+  setTransition: (trackId: string, clipId: string, transition: ClipTransition) => void;
+  removeTransition: (trackId: string, clipId: string) => void;
+
   // カット編集機能
   setSelectedClip: (trackId: string | null, clipId: string | null) => void;
   splitClipAtTime: (trackId: string, clipId: string, splitTime: number) => void;
@@ -191,6 +211,33 @@ export const useTimelineStore = create<TimelineState>((set) => ({
     pixelsPerSecond: Math.max(state.pixelsPerSecond / 1.2, 10),
   })),
   
+  // トランジション
+  setTransition: (trackId, clipId, transition) => set((state) => ({
+    tracks: state.tracks.map(track =>
+      track.id === trackId
+        ? {
+            ...track,
+            clips: track.clips.map(clip =>
+              clip.id === clipId ? { ...clip, transition } : clip
+            ),
+          }
+        : track
+    ),
+  })),
+
+  removeTransition: (trackId, clipId) => set((state) => ({
+    tracks: state.tracks.map(track =>
+      track.id === trackId
+        ? {
+            ...track,
+            clips: track.clips.map(clip =>
+              clip.id === clipId ? { ...clip, transition: undefined } : clip
+            ),
+          }
+        : track
+    ),
+  })),
+
   // カット編集機能
   setSelectedClip: (trackId, clipId) => set({
     selectedTrackId: trackId,

--- a/src/test/timelineStore.test.ts
+++ b/src/test/timelineStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useTimelineStore } from '../store/timelineStore';
+import { useTimelineStore, type ClipTransition } from '../store/timelineStore';
 
 describe('timelineStore', () => {
   beforeEach(() => {
@@ -97,7 +97,7 @@ describe('timelineStore', () => {
 
   it('should not zoom beyond limits', () => {
     const { zoomIn, zoomOut } = useTimelineStore.getState();
-    
+
     // Zoom in to max
     for (let i = 0; i < 20; i++) {
       zoomIn();
@@ -111,5 +111,73 @@ describe('timelineStore', () => {
     }
     const minState = useTimelineStore.getState();
     expect(minState.pixelsPerSecond).toBeGreaterThanOrEqual(10);
+  });
+
+  describe('transition', () => {
+    const transition: ClipTransition = { type: 'crossfade', duration: 1.0 };
+
+    beforeEach(() => {
+      const { addTrack, addClip } = useTimelineStore.getState();
+      addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+      addClip('video-1', {
+        id: 'clip-1',
+        name: 'Clip 1',
+        startTime: 0,
+        duration: 5,
+        filePath: 'a.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      });
+      addClip('video-1', {
+        id: 'clip-2',
+        name: 'Clip 2',
+        startTime: 5,
+        duration: 5,
+        filePath: 'b.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      });
+    });
+
+    it('should set transition on a clip', () => {
+      const { setTransition } = useTimelineStore.getState();
+      setTransition('video-1', 'clip-2', transition);
+
+      const state = useTimelineStore.getState();
+      const track = state.tracks.find(t => t.id === 'video-1');
+      const clip = track!.clips.find(c => c.id === 'clip-2');
+      expect(clip!.transition).toEqual(transition);
+    });
+
+    it('should remove transition from a clip', () => {
+      const { setTransition, removeTransition } = useTimelineStore.getState();
+      setTransition('video-1', 'clip-2', transition);
+      removeTransition('video-1', 'clip-2');
+
+      const state = useTimelineStore.getState();
+      const track = state.tracks.find(t => t.id === 'video-1');
+      const clip = track!.clips.find(c => c.id === 'clip-2');
+      expect(clip!.transition).toBeUndefined();
+    });
+
+    it('should not affect other clips when setting transition', () => {
+      const { setTransition } = useTimelineStore.getState();
+      setTransition('video-1', 'clip-2', transition);
+
+      const state = useTimelineStore.getState();
+      const track = state.tracks.find(t => t.id === 'video-1');
+      const clip1 = track!.clips.find(c => c.id === 'clip-1');
+      expect(clip1!.transition).toBeUndefined();
+    });
+
+    it('should handle setting transition on non-existent clip gracefully', () => {
+      const { setTransition } = useTimelineStore.getState();
+      setTransition('video-1', 'non-existent', transition);
+
+      const state = useTimelineStore.getState();
+      const track = state.tracks.find(t => t.id === 'video-1');
+      expect(track!.clips).toHaveLength(2);
+      expect(track!.clips.every(c => c.transition === undefined)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `TransitionType` 型（crossfade, wipe-left/right/up/down, dissolve）と `ClipTransition` インターフェースを追加
- `Clip` インターフェースに `transition?: ClipTransition` フィールドを追加
- `timelineStore` に `setTransition` / `removeTransition` アクションを追加
- トランジション操作のユニットテスト4件を追加

## Test plan
- [x] `npm run test` — 全37テストがパス
- [x] `npm run lint` — エラーなし
- [x] `npm run build` — ビルド成功

Closes #39