### PR TITLE
トランジション: タイムラインUIでの表示・編集

### DIFF
--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -1,6 +1,7 @@
 import { useTimelineStore, Clip as ClipType } from '../../store/timelineStore';
 import { useVideoPreviewStore } from '../../store/videoPreviewStore';
 import { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface ClipProps {
   clip: ClipType;
@@ -8,6 +9,7 @@ interface ClipProps {
 }
 
 function Clip({ clip, trackId }: ClipProps) {
+  const { t } = useTranslation();
   const {
     pixelsPerSecond,
     removeClip,
@@ -15,6 +17,9 @@ function Clip({ clip, trackId }: ClipProps) {
     selectedClipId,
     splitClipAtTime,
     updateClip,
+    setTransition,
+    removeTransition,
+    tracks,
   } = useTimelineStore();
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
@@ -26,6 +31,11 @@ function Clip({ clip, trackId }: ClipProps) {
   const left = clip.startTime * pixelsPerSecond;
   const width = clip.duration * pixelsPerSecond;
   const isSelected = selectedClipId === clip.id;
+
+  const track = tracks.find(t => t.id === trackId);
+  const clipIndex = track ? track.clips.findIndex(c => c.id === clip.id) : -1;
+  const hasPreviousClip = clipIndex > 0;
+  const hasTransition = !!clip.transition;
 
   const handleMouseDown = (e: React.MouseEvent) => {
     if ((e.target as HTMLElement).classList.contains('clip-resize-handle')) {
@@ -100,6 +110,18 @@ function Clip({ clip, trackId }: ClipProps) {
     setShowContextMenu(false);
   };
 
+  const handleAddTransition = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setTransition(trackId, clip.id, { type: 'crossfade', duration: 1.0 });
+    setShowContextMenu(false);
+  };
+
+  const handleRemoveTransition = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    removeTransition(trackId, clip.id);
+    setShowContextMenu(false);
+  };
+
   const handleCloseContextMenu = () => {
     setShowContextMenu(false);
   };
@@ -139,6 +161,16 @@ function Clip({ clip, trackId }: ClipProps) {
             <button className="context-menu-item" onClick={handleSplit}>
               ✂️ 分割
             </button>
+            {hasPreviousClip && !hasTransition && (
+              <button className="context-menu-item" onClick={handleAddTransition}>
+                🔄 {t('transition.add')}
+              </button>
+            )}
+            {hasTransition && (
+              <button className="context-menu-item" onClick={handleRemoveTransition}>
+                🔄 {t('transition.remove')}
+              </button>
+            )}
             <button className="context-menu-item" onClick={handleDelete}>
               🗑️ 削除
             </button>

--- a/src/components/Timeline/Timeline.css
+++ b/src/components/Timeline/Timeline.css
@@ -329,3 +329,108 @@
   background-color: #3a3a3a;
 }
 
+/* トランジションインジケーター */
+.transition-indicator {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(255, 165, 0, 0.3), rgba(255, 165, 0, 0.15), rgba(255, 165, 0, 0.3));
+  border: 1px dashed rgba(255, 165, 0, 0.6);
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 8;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.transition-indicator:hover {
+  background: linear-gradient(90deg, rgba(255, 165, 0, 0.5), rgba(255, 165, 0, 0.25), rgba(255, 165, 0, 0.5));
+  border-color: rgba(255, 165, 0, 0.9);
+}
+
+.transition-icon {
+  font-size: 1rem;
+  color: #ffa500;
+  line-height: 1;
+}
+
+.transition-label {
+  font-size: 0.625rem;
+  color: #ffa500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+/* トランジションポップオーバー */
+.transition-popover {
+  position: absolute;
+  top: 100%;
+  margin-top: 4px;
+  background-color: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  min-width: 160px;
+  padding: 8px;
+}
+
+.transition-popover-types {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 8px;
+}
+
+.transition-popover-item {
+  padding: 6px 8px;
+  background: none;
+  border: none;
+  color: #ccc;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  border-radius: 3px;
+}
+
+.transition-popover-item:hover {
+  background-color: #3a3a3a;
+  color: #fff;
+}
+
+.transition-popover-item.active {
+  background-color: #4a9eff;
+  color: #fff;
+}
+
+.transition-popover-duration {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid #3a3a3a;
+  font-size: 0.75rem;
+  color: #aaa;
+}
+
+.transition-popover-duration label {
+  white-space: nowrap;
+}
+
+.transition-popover-duration input[type="range"] {
+  flex: 1;
+  height: 4px;
+  accent-color: #4a9eff;
+}
+
+.transition-popover-duration span {
+  min-width: 32px;
+  text-align: right;
+  color: #fff;
+}
+

--- a/src/components/Timeline/Track.tsx
+++ b/src/components/Timeline/Track.tsx
@@ -1,5 +1,6 @@
 import { Track as TrackType } from '../../store/timelineStore';
 import Clip from './Clip';
+import TransitionIndicator from './TransitionIndicator';
 
 interface TrackProps {
   track: TrackType;
@@ -12,6 +13,17 @@ function Track({ track }: TrackProps) {
         {track.clips.map(clip => (
           <Clip key={clip.id} clip={clip} trackId={track.id} />
         ))}
+        {track.clips
+          .filter(clip => clip.transition)
+          .map(clip => (
+            <TransitionIndicator
+              key={`transition-${clip.id}`}
+              transition={clip.transition!}
+              clipId={clip.id}
+              trackId={track.id}
+              clipStartTime={clip.startTime}
+            />
+          ))}
       </div>
     </div>
   );

--- a/src/components/Timeline/TransitionIndicator.tsx
+++ b/src/components/Timeline/TransitionIndicator.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTimelineStore, type ClipTransition, type TransitionType } from '../../store/timelineStore';
+
+interface TransitionIndicatorProps {
+  transition: ClipTransition;
+  clipId: string;
+  trackId: string;
+  clipStartTime: number;
+}
+
+const TRANSITION_TYPES: TransitionType[] = [
+  'crossfade',
+  'dissolve',
+  'wipe-left',
+  'wipe-right',
+  'wipe-up',
+  'wipe-down',
+];
+
+const TRANSITION_I18N_KEYS: Record<TransitionType, string> = {
+  'crossfade': 'transition.crossfade',
+  'dissolve': 'transition.dissolve',
+  'wipe-left': 'transition.wipeLeft',
+  'wipe-right': 'transition.wipeRight',
+  'wipe-up': 'transition.wipeUp',
+  'wipe-down': 'transition.wipeDown',
+};
+
+function TransitionIndicator({ transition, clipId, trackId, clipStartTime }: TransitionIndicatorProps) {
+  const { t } = useTranslation();
+  const { pixelsPerSecond, setTransition, removeTransition } = useTimelineStore();
+  const [showPopover, setShowPopover] = useState(false);
+  const [showContextMenu, setShowContextMenu] = useState(false);
+  const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
+
+  const width = transition.duration * pixelsPerSecond;
+  const left = clipStartTime * pixelsPerSecond - width / 2;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowPopover(!showPopover);
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+    setShowContextMenu(true);
+  };
+
+  const handleSelectType = (type: TransitionType) => {
+    setTransition(trackId, clipId, { ...transition, type });
+    setShowPopover(false);
+  };
+
+  const handleDurationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const duration = parseFloat(e.target.value);
+    setTransition(trackId, clipId, { ...transition, duration });
+  };
+
+  const handleRemove = () => {
+    removeTransition(trackId, clipId);
+    setShowContextMenu(false);
+  };
+
+  return (
+    <>
+      <div
+        className="transition-indicator"
+        style={{ left: `${left}px`, width: `${width}px` }}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        title={t(TRANSITION_I18N_KEYS[transition.type])}
+      >
+        <span className="transition-icon">◆</span>
+        <span className="transition-label">
+          {t(TRANSITION_I18N_KEYS[transition.type])}
+        </span>
+      </div>
+
+      {showPopover && (
+        <>
+          <div className="context-menu-overlay" onClick={() => setShowPopover(false)} />
+          <div
+            className="transition-popover"
+            style={{ left: `${left}px` }}
+          >
+            <div className="transition-popover-types">
+              {TRANSITION_TYPES.map(type => (
+                <button
+                  key={type}
+                  className={`transition-popover-item ${type === transition.type ? 'active' : ''}`}
+                  onClick={(e) => { e.stopPropagation(); handleSelectType(type); }}
+                >
+                  {t(TRANSITION_I18N_KEYS[type])}
+                </button>
+              ))}
+            </div>
+            <div className="transition-popover-duration">
+              <label>{t('transition.duration')}</label>
+              <input
+                type="range"
+                min="0.1"
+                max="3.0"
+                step="0.1"
+                value={transition.duration}
+                onChange={handleDurationChange}
+                onClick={(e) => e.stopPropagation()}
+              />
+              <span>{transition.duration.toFixed(1)}s</span>
+            </div>
+          </div>
+        </>
+      )}
+
+      {showContextMenu && (
+        <>
+          <div className="context-menu-overlay" onClick={() => setShowContextMenu(false)} />
+          <div
+            className="context-menu"
+            style={{ left: `${contextMenuPos.x}px`, top: `${contextMenuPos.y}px` }}
+          >
+            <button className="context-menu-item" onClick={handleRemove}>
+              🗑️ {t('transition.remove')}
+            </button>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+export default TransitionIndicator;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -79,6 +79,17 @@
     "exportSubtitle": "Export",
     "noTextSelected": "Select a text clip"
   },
+  "transition": {
+    "add": "Add Transition",
+    "remove": "Remove Transition",
+    "crossfade": "Crossfade",
+    "dissolve": "Dissolve",
+    "wipeLeft": "Wipe Left",
+    "wipeRight": "Wipe Right",
+    "wipeUp": "Wipe Up",
+    "wipeDown": "Wipe Down",
+    "duration": "Duration"
+  },
   "export": {
     "title": "Export Video",
     "button": "Export",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -79,6 +79,17 @@
     "exportSubtitle": "字幕書出",
     "noTextSelected": "テキストクリップを選択してください"
   },
+  "transition": {
+    "add": "トランジション追加",
+    "remove": "トランジション削除",
+    "crossfade": "クロスフェード",
+    "dissolve": "ディゾルブ",
+    "wipeLeft": "ワイプ左",
+    "wipeRight": "ワイプ右",
+    "wipeUp": "ワイプ上",
+    "wipeDown": "ワイプ下",
+    "duration": "時間"
+  },
   "export": {
     "title": "動画エクスポート",
     "button": "エクスポート",

--- a/src/test/transitionUI.test.ts
+++ b/src/test/transitionUI.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTimelineStore } from '../store/timelineStore';
+
+describe('transition UI integration', () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [],
+      selectedClipId: null,
+      selectedTrackId: null,
+      currentTime: 0,
+      isPlaying: false,
+      pixelsPerSecond: 50,
+    });
+
+    const { addTrack, addClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+    addClip('video-1', {
+      id: 'clip-2',
+      name: 'Clip 2',
+      startTime: 5,
+      duration: 5,
+      filePath: 'b.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+  });
+
+  it('should add default crossfade transition via context menu action', () => {
+    const { setTransition } = useTimelineStore.getState();
+    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+
+    const state = useTimelineStore.getState();
+    const track = state.tracks.find(t => t.id === 'video-1');
+    const clip2 = track!.clips.find(c => c.id === 'clip-2');
+    expect(clip2!.transition).toEqual({ type: 'crossfade', duration: 1.0 });
+  });
+
+  it('should remove transition via context menu action', () => {
+    const { setTransition, removeTransition } = useTimelineStore.getState();
+    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+    removeTransition('video-1', 'clip-2');
+
+    const state = useTimelineStore.getState();
+    const track = state.tracks.find(t => t.id === 'video-1');
+    const clip2 = track!.clips.find(c => c.id === 'clip-2');
+    expect(clip2!.transition).toBeUndefined();
+  });
+
+  it('should change transition type', () => {
+    const { setTransition } = useTimelineStore.getState();
+    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+    setTransition('video-1', 'clip-2', { type: 'dissolve', duration: 1.0 });
+
+    const state = useTimelineStore.getState();
+    const track = state.tracks.find(t => t.id === 'video-1');
+    const clip2 = track!.clips.find(c => c.id === 'clip-2');
+    expect(clip2!.transition!.type).toBe('dissolve');
+  });
+
+  it('should change transition duration', () => {
+    const { setTransition } = useTimelineStore.getState();
+    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 2.5 });
+
+    const state = useTimelineStore.getState();
+    const track = state.tracks.find(t => t.id === 'video-1');
+    const clip2 = track!.clips.find(c => c.id === 'clip-2');
+    expect(clip2!.transition!.duration).toBe(2.5);
+  });
+
+  it('should identify first clip has no previous clip', () => {
+    const state = useTimelineStore.getState();
+    const track = state.tracks.find(t => t.id === 'video-1');
+    const clipIndex = track!.clips.findIndex(c => c.id === 'clip-1');
+    expect(clipIndex).toBe(0);
+    // First clip should not have a "previous" clip
+    expect(clipIndex > 0).toBe(false);
+  });
+
+  it('should identify second clip has a previous clip', () => {
+    const state = useTimelineStore.getState();
+    const track = state.tracks.find(t => t.id === 'video-1');
+    const clipIndex = track!.clips.findIndex(c => c.id === 'clip-2');
+    expect(clipIndex).toBe(1);
+    expect(clipIndex > 0).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `TransitionIndicator` コンポーネント新規作成（クリップ間のオーバーラップ帯表示、種類選択ポップオーバー、duration調整スライダー）
- `Clip.tsx` のコンテキストメニューにトランジション追加/削除メニュー項目を追加（前クリップが存在する場合のみ表示）
- `Track.tsx` にトランジションインジケーター表示を組み込み
- `Timeline.css` にトランジション関連スタイルを追加
- i18n対応（日本語・英語の翻訳キー追加）
- トランジションUI統合テスト6件を追加

## Test plan
- [x] `npm run lint` — エラーなし
- [x] `npm run test` — 全43テストパス
- [x] `npm run build` — ビルド成功

Closes #40