### PR TITLE
異なるトラック間のクリップにトランジション機能を追加

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -138,6 +138,20 @@ pub struct ExportTrack {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct ExportCrossTrackTransition {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub transition_type: String,
+    pub duration: f64,
+    pub source_track_id: String,
+    pub source_clip_id: String,
+    pub target_track_id: String,
+    pub target_clip_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExportSettings {
     pub format: String,
     pub width: u32,
@@ -146,6 +160,8 @@ pub struct ExportSettings {
     pub fps: u32,
     pub output_path: String,
     pub tracks: Vec<ExportTrack>,
+    #[serde(default)]
+    pub cross_track_transitions: Vec<ExportCrossTrackTransition>,
     pub total_duration: f64,
 }
 
@@ -398,6 +414,29 @@ fn transition_to_xfade(t: &str) -> &str {
     }
 }
 
+fn find_cross_track_transition_for_clip<'a>(
+    clip_id: &str,
+    cross_track_transitions: &'a [ExportCrossTrackTransition],
+) -> Option<&'a ExportCrossTrackTransition> {
+    cross_track_transitions
+        .iter()
+        .find(|ct| ct.target_clip_id == clip_id)
+}
+
+fn find_source_clip_in_tracks<'a>(
+    source_clip_id: &str,
+    tracks: &'a [ExportTrack],
+) -> Option<&'a ExportClip> {
+    for track in tracks {
+        for clip in &track.clips {
+            if clip.id == source_clip_id {
+                return Some(clip);
+            }
+        }
+    }
+    None
+}
+
 fn build_ffmpeg_args(
     settings: &ExportSettings,
     video_clips: &[&ExportClip],
@@ -416,6 +455,17 @@ fn build_ffmpeg_args(
             input_args.push("-i".into());
             input_args.push(clip.file_path.clone());
             input_index += 1;
+        }
+    }
+    // クロストラックトランジションのソースクリップも入力に追加
+    for ct in &settings.cross_track_transitions {
+        if let Some(source_clip) = find_source_clip_in_tracks(&ct.source_clip_id, &settings.tracks) {
+            if !source_clip.file_path.is_empty() && !input_map.contains_key(&source_clip.file_path) {
+                input_map.insert(source_clip.file_path.clone(), input_index);
+                input_args.push("-i".into());
+                input_args.push(source_clip.file_path.clone());
+                input_index += 1;
+            }
         }
     }
 
@@ -522,11 +572,53 @@ fn build_ffmpeg_args(
             idx, clip.source_start_time, clip.source_end_time, a_label
         ));
 
-        // トランジション情報
+        // トランジション情報（同一トラック or クロストラック）
         let clip_duration = clip.source_end_time - clip.source_start_time;
-        let trans_info = clip.transition.as_ref().map(|t| {
+        let mut trans_info = clip.transition.as_ref().map(|t| {
             (transition_to_xfade(&t.transition_type).to_string(), t.duration)
         });
+
+        // クロストラックトランジション: ターゲットクリップの場合、
+        // ソースクリップのセグメントを先に挿入し、xfadeで結合する
+        if trans_info.is_none() {
+            if let Some(ct) = find_cross_track_transition_for_clip(&clip.id, &settings.cross_track_transitions) {
+                if let Some(source_clip) = find_source_clip_in_tracks(&ct.source_clip_id, &settings.tracks) {
+                    if let Some(src_idx) = input_map.get(&source_clip.file_path) {
+                        let ct_src_v = format!("ctv{}", i);
+                        let ct_src_a = format!("cta{}", i);
+                        let src_duration = source_clip.source_end_time - source_clip.source_start_time;
+
+                        let mut src_vfilter = format!(
+                            "[{}:v]trim=start={:.3}:end={:.3},setpts=PTS-STARTPTS",
+                            src_idx, source_clip.source_start_time, source_clip.source_end_time
+                        );
+                        src_vfilter.push_str(&format!(
+                            ",scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2:black",
+                            w, h, w, h
+                        ));
+                        src_vfilter.push_str(&format!("[{}]", ct_src_v));
+                        filter_parts.push(src_vfilter);
+
+                        filter_parts.push(format!(
+                            "[{}:a]atrim=start={:.3}:end={:.3},asetpts=PTS-STARTPTS[{}]",
+                            src_idx, source_clip.source_start_time, source_clip.source_end_time, ct_src_a
+                        ));
+
+                        segments.push(SegmentInfo {
+                            v_label: ct_src_v,
+                            a_label: ct_src_a,
+                            duration: src_duration,
+                            transition: None,
+                        });
+
+                        trans_info = Some((
+                            transition_to_xfade(&ct.transition_type).to_string(),
+                            ct.duration,
+                        ));
+                    }
+                }
+            }
+        }
 
         segments.push(SegmentInfo {
             v_label,

--- a/src/components/Export/ExportDialog.tsx
+++ b/src/components/Export/ExportDialog.tsx
@@ -55,6 +55,7 @@ export const ExportDialog: React.FC = () => {
     exportStartedAt,
   } = useExportStore();
   const tracks = useTimelineStore((s) => s.tracks);
+  const crossTrackTransitions = useTimelineStore((s) => s.crossTrackTransitions);
   const duration = useTimelineStore((s) => s.duration);
 
   // バックエンドからの進捗イベントをリッスン
@@ -108,13 +109,14 @@ export const ExportDialog: React.FC = () => {
           ...settings,
           outputPath,
           tracks,
+          crossTrackTransitions,
           totalDuration: duration,
         },
       });
     } catch (e) {
       setError(String(e));
     }
-  }, [outputPath, settings, tracks, duration, setStatus, setProgress, setError, t]);
+  }, [outputPath, settings, tracks, crossTrackTransitions, duration, setStatus, setProgress, setError, t]);
 
   const handleCancel = useCallback(async () => {
     try {

--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -1,7 +1,7 @@
 import { useTimelineStore, Clip as ClipType } from '../../store/timelineStore';
 import { useVideoPreviewStore } from '../../store/videoPreviewStore';
 import { useTransitionPresetStore } from '../../store/transitionPresetStore';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface ClipProps {
@@ -13,6 +13,8 @@ function Clip({ clip, trackId }: ClipProps) {
   const { t } = useTranslation();
   const {
     pixelsPerSecond,
+    tracks,
+    crossTrackTransitions,
     removeClip,
     setSelectedClip,
     selectedClipId,
@@ -20,15 +22,43 @@ function Clip({ clip, trackId }: ClipProps) {
     updateClip,
     setTransition,
     removeTransition,
+    addCrossTrackTransition,
   } = useTimelineStore();
   const allPresets = useTransitionPresetStore((s) => s.getAllPresets)();
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [showTransitionSubmenu, setShowTransitionSubmenu] = useState(false);
+  const [showCrossTrackSubmenu, setShowCrossTrackSubmenu] = useState(false);
+
+  // 他トラックで時間的に重複するクリップを検索
+  const overlappingClipsOnOtherTracks = useMemo(() => {
+    const clipEnd = clip.startTime + clip.duration;
+    const result: { trackId: string; trackName: string; clip: ClipType }[] = [];
+    for (const track of tracks) {
+      if (track.id === trackId) continue;
+      if (track.type !== 'video') continue;
+      for (const otherClip of track.clips) {
+        const otherEnd = otherClip.startTime + otherClip.duration;
+        if (clip.startTime < otherEnd && otherClip.startTime < clipEnd) {
+          // 既にクロストラックトランジションが存在するペアは除外
+          const alreadyExists = crossTrackTransitions.some(
+            (ct) =>
+              (ct.sourceClipId === clip.id && ct.targetClipId === otherClip.id) ||
+              (ct.sourceClipId === otherClip.id && ct.targetClipId === clip.id)
+          );
+          if (!alreadyExists) {
+            result.push({ trackId: track.id, trackName: track.name, clip: otherClip });
+          }
+        }
+      }
+    }
+    return result;
+  }, [tracks, trackId, clip, crossTrackTransitions]);
   const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
+  const crossTrackSubmenuRef = useRef<HTMLDivElement>(null);
   const dragStartX = useRef(0);
   const dragStartTime = useRef(0);
 
@@ -157,6 +187,27 @@ function Clip({ clip, trackId }: ClipProps) {
     }
   }, [showTransitionSubmenu]);
 
+  // クロストラックサブメニューが画面外にはみ出る場合、位置を自動補正
+  useEffect(() => {
+    if (!showCrossTrackSubmenu || !crossTrackSubmenuRef.current) return;
+    const submenu = crossTrackSubmenuRef.current;
+    const rect = submenu.getBoundingClientRect();
+    if (rect.bottom > window.innerHeight) {
+      submenu.style.top = 'auto';
+      submenu.style.bottom = '0';
+    } else {
+      submenu.style.top = '0';
+      submenu.style.bottom = 'auto';
+    }
+    if (rect.right > window.innerWidth) {
+      submenu.style.left = 'auto';
+      submenu.style.right = '100%';
+    } else {
+      submenu.style.left = '100%';
+      submenu.style.right = 'auto';
+    }
+  }, [showCrossTrackSubmenu]);
+
   const handleCloseContextMenu = () => {
     setShowContextMenu(false);
   };
@@ -227,6 +278,40 @@ function Clip({ clip, trackId }: ClipProps) {
               <button className="context-menu-item" onClick={handleRemoveTransition}>
                 🔄 {t('transition.remove')}
               </button>
+            )}
+            {overlappingClipsOnOtherTracks.length > 0 && (
+              <div
+                className="context-menu-item context-menu-submenu-trigger"
+                onMouseEnter={() => setShowCrossTrackSubmenu(true)}
+                onMouseLeave={() => setShowCrossTrackSubmenu(false)}
+              >
+                🔀 {t('transition.addCrossTrack')} ▸
+                {showCrossTrackSubmenu && (
+                  <div ref={crossTrackSubmenuRef} className="context-submenu">
+                    {overlappingClipsOnOtherTracks.map(({ trackId: otherTrackId, trackName, clip: otherClip }) => (
+                      <button
+                        key={otherClip.id}
+                        className="context-menu-item"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          addCrossTrackTransition({
+                            id: `ct-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                            type: 'crossfade',
+                            duration: 1.0,
+                            sourceTrackId: trackId,
+                            sourceClipId: clip.id,
+                            targetTrackId: otherTrackId,
+                            targetClipId: otherClip.id,
+                          });
+                          setShowContextMenu(false);
+                        }}
+                      >
+                        {trackName}: {otherClip.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
             <button className="context-menu-item" onClick={handleDelete}>
               🗑️ 削除

--- a/src/components/Timeline/CrossTrackTransitionIndicator.tsx
+++ b/src/components/Timeline/CrossTrackTransitionIndicator.tsx
@@ -1,0 +1,302 @@
+import { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useTimelineStore,
+  type CrossTrackTransition,
+  type Clip as ClipType,
+  type TransitionType,
+} from '../../store/timelineStore';
+import { useTransitionPresetStore } from '../../store/transitionPresetStore';
+
+interface CrossTrackTransitionIndicatorProps {
+  transition: CrossTrackTransition;
+  sourceClip: ClipType;
+  targetClip: ClipType;
+  sourceTrackIndex: number;
+  targetTrackIndex: number;
+}
+
+const TRANSITION_TYPES: TransitionType[] = [
+  'crossfade',
+  'dissolve',
+  'wipe-left',
+  'wipe-right',
+  'wipe-up',
+  'wipe-down',
+];
+
+const TRANSITION_I18N_KEYS: Record<TransitionType, string> = {
+  'crossfade': 'transition.crossfade',
+  'dissolve': 'transition.dissolve',
+  'wipe-left': 'transition.wipeLeft',
+  'wipe-right': 'transition.wipeRight',
+  'wipe-up': 'transition.wipeUp',
+  'wipe-down': 'transition.wipeDown',
+};
+
+function CrossTrackTransitionIndicator({
+  transition,
+  sourceClip,
+  targetClip,
+  sourceTrackIndex,
+  targetTrackIndex,
+}: CrossTrackTransitionIndicatorProps) {
+  const { t } = useTranslation();
+  const { pixelsPerSecond, updateCrossTrackTransition, removeCrossTrackTransition } = useTimelineStore();
+  const allPresets = useTransitionPresetStore((s) => s.getAllPresets)();
+  const addPreset = useTransitionPresetStore((s) => s.addPreset);
+  const removePreset = useTransitionPresetStore((s) => s.removePreset);
+  const [showPopover, setShowPopover] = useState(false);
+  const [showContextMenu, setShowContextMenu] = useState(false);
+  const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
+  const [popoverPos, setPopoverPos] = useState({ x: 0, y: 0 });
+  const [presetName, setPresetName] = useState('');
+  const [showSaveInput, setShowSaveInput] = useState(false);
+  const indicatorRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+
+  // 重複区間を計算
+  const overlapStart = Math.max(sourceClip.startTime, targetClip.startTime);
+  const overlapEnd = Math.min(
+    sourceClip.startTime + sourceClip.duration,
+    targetClip.startTime + targetClip.duration,
+  );
+  const transEnd = Math.min(overlapStart + transition.duration, overlapEnd);
+  const effectiveDuration = transEnd - overlapStart;
+
+  const left = overlapStart * pixelsPerSecond;
+  const width = effectiveDuration * pixelsPerSecond;
+
+  // トラック位置を計算（ルーラー高さ + トラック高さ × インデックス）
+  const rulerHeight = 30;
+  const trackHeight = 60;
+  const topTrackIndex = Math.min(sourceTrackIndex, targetTrackIndex);
+  const bottomTrackIndex = Math.max(sourceTrackIndex, targetTrackIndex);
+  const top = rulerHeight + topTrackIndex * trackHeight;
+  const height = (bottomTrackIndex - topTrackIndex + 1) * trackHeight;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!showPopover && indicatorRef.current) {
+      const rect = indicatorRef.current.getBoundingClientRect();
+      setPopoverPos({ x: rect.left, y: rect.bottom + 4 });
+    }
+    setShowPopover(!showPopover);
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+    setShowContextMenu(true);
+  };
+
+  const handleSelectType = (type: TransitionType) => {
+    updateCrossTrackTransition(transition.id, { type });
+    setShowPopover(false);
+  };
+
+  const handleDurationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const duration = parseFloat(e.target.value);
+    updateCrossTrackTransition(transition.id, { duration });
+  };
+
+  const handleRemove = () => {
+    removeCrossTrackTransition(transition.id);
+    setShowContextMenu(false);
+  };
+
+  // ポップオーバー位置自動補正
+  useEffect(() => {
+    if (!showPopover || !popoverRef.current || !indicatorRef.current) return;
+    const popover = popoverRef.current;
+    const rect = popover.getBoundingClientRect();
+    const indicatorRect = indicatorRef.current.getBoundingClientRect();
+    let { x, y } = popoverPos;
+    if (rect.bottom > window.innerHeight) {
+      y = indicatorRect.top - rect.height - 4;
+    }
+    if (rect.right > window.innerWidth) {
+      x = window.innerWidth - rect.width;
+    }
+    if (x < 0) x = 0;
+    if (y < 0) y = 0;
+    if (x !== popoverPos.x || y !== popoverPos.y) {
+      setPopoverPos({ x, y });
+    }
+  }, [showPopover, popoverPos]);
+
+  // コンテキストメニュー位置自動補正
+  useEffect(() => {
+    if (!showContextMenu || !contextMenuRef.current) return;
+    const menu = contextMenuRef.current;
+    const rect = menu.getBoundingClientRect();
+    let { x, y } = contextMenuPos;
+    if (rect.right > window.innerWidth) {
+      x = window.innerWidth - rect.width;
+    }
+    if (rect.bottom > window.innerHeight) {
+      y = window.innerHeight - rect.height;
+    }
+    if (x !== contextMenuPos.x || y !== contextMenuPos.y) {
+      setContextMenuPos({ x, y });
+    }
+  }, [showContextMenu, contextMenuPos]);
+
+  return (
+    <>
+      <div
+        ref={indicatorRef}
+        className="cross-track-transition-indicator"
+        style={{
+          left: `${left}px`,
+          width: `${width}px`,
+          top: `${top}px`,
+          height: `${height}px`,
+        }}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        title={`${t('transition.crossTrack')}: ${t(TRANSITION_I18N_KEYS[transition.type])}`}
+      >
+        <span className="cross-track-transition-icon">⬥</span>
+        <span className="cross-track-transition-label">
+          {t(TRANSITION_I18N_KEYS[transition.type])}
+        </span>
+      </div>
+
+      {showPopover && (
+        <>
+          <div className="context-menu-overlay" onClick={() => setShowPopover(false)} />
+          <div
+            ref={popoverRef}
+            className="transition-popover"
+            style={{
+              position: 'fixed',
+              left: `${popoverPos.x}px`,
+              top: `${popoverPos.y}px`,
+              margin: 0,
+            }}
+          >
+            {/* プリセット選択 */}
+            <div className="transition-popover-presets">
+              <label className="transition-popover-section-label">{t('preset.selectPreset')}</label>
+              <div className="transition-popover-preset-list">
+                {allPresets.map(preset => (
+                  <div key={preset.id} className="transition-popover-preset-row">
+                    <button
+                      className="transition-popover-item"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        updateCrossTrackTransition(transition.id, { type: preset.type, duration: preset.duration });
+                      }}
+                    >
+                      {preset.isBuiltIn ? t(preset.name) : preset.name}
+                    </button>
+                    {!preset.isBuiltIn && (
+                      <button
+                        className="transition-popover-preset-delete"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removePreset(preset.id);
+                        }}
+                        title={t('preset.delete')}
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 種類選択 */}
+            <div className="transition-popover-types">
+              {TRANSITION_TYPES.map(type => (
+                <button
+                  key={type}
+                  className={`transition-popover-item ${type === transition.type ? 'active' : ''}`}
+                  onClick={(e) => { e.stopPropagation(); handleSelectType(type); }}
+                >
+                  {t(TRANSITION_I18N_KEYS[type])}
+                </button>
+              ))}
+            </div>
+            <div className="transition-popover-duration">
+              <label>{t('transition.duration')}</label>
+              <input
+                type="range"
+                min="0.1"
+                max="3.0"
+                step="0.1"
+                value={transition.duration}
+                onChange={handleDurationChange}
+                onClick={(e) => e.stopPropagation()}
+              />
+              <span>{transition.duration.toFixed(1)}s</span>
+            </div>
+
+            {/* プリセット保存 */}
+            <div className="transition-popover-save">
+              {showSaveInput ? (
+                <div className="transition-popover-save-input">
+                  <input
+                    type="text"
+                    value={presetName}
+                    onChange={(e) => setPresetName(e.target.value)}
+                    placeholder={t('preset.namePlaceholder')}
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && presetName.trim()) {
+                        addPreset(presetName.trim(), transition.type, transition.duration);
+                        setPresetName('');
+                        setShowSaveInput(false);
+                      }
+                    }}
+                  />
+                  <button
+                    className="transition-popover-save-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (presetName.trim()) {
+                        addPreset(presetName.trim(), transition.type, transition.duration);
+                        setPresetName('');
+                        setShowSaveInput(false);
+                      }
+                    }}
+                  >
+                    ✓
+                  </button>
+                </div>
+              ) : (
+                <button
+                  className="transition-popover-item"
+                  onClick={(e) => { e.stopPropagation(); setShowSaveInput(true); }}
+                >
+                  💾 {t('preset.save')}
+                </button>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {showContextMenu && (
+        <>
+          <div className="context-menu-overlay" onClick={() => setShowContextMenu(false)} />
+          <div
+            ref={contextMenuRef}
+            className="context-menu"
+            style={{ left: `${contextMenuPos.x}px`, top: `${contextMenuPos.y}px` }}
+          >
+            <button className="context-menu-item" onClick={handleRemove}>
+              🗑️ {t('transition.remove')}
+            </button>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+export default CrossTrackTransitionIndicator;

--- a/src/components/Timeline/Timeline.css
+++ b/src/components/Timeline/Timeline.css
@@ -544,3 +544,38 @@
   width: 100%;
 }
 
+/* クロストラックトランジションインジケーター */
+.cross-track-transition-indicator {
+  position: absolute;
+  background: linear-gradient(90deg, rgba(0, 200, 255, 0.15), rgba(0, 200, 255, 0.08), rgba(0, 200, 255, 0.15));
+  border: 1px dashed rgba(0, 200, 255, 0.5);
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 7;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  pointer-events: auto;
+}
+
+.cross-track-transition-indicator:hover {
+  background: linear-gradient(90deg, rgba(0, 200, 255, 0.25), rgba(0, 200, 255, 0.15), rgba(0, 200, 255, 0.25));
+  border-color: rgba(0, 200, 255, 0.8);
+}
+
+.cross-track-transition-icon {
+  font-size: 0.75rem;
+  color: #00c8ff;
+}
+
+.cross-track-transition-label {
+  font-size: 0.625rem;
+  color: #00c8ff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -3,6 +3,7 @@ import { useVideoPreviewStore } from '../../store/videoPreviewStore';
 import { useEffect, useRef, useState } from 'react';
 import Track from './Track';
 import Playhead from './Playhead';
+import CrossTrackTransitionIndicator from './CrossTrackTransitionIndicator';
 import './Timeline.css';
 
 // タイムコード表示を分離して、currentTime 更新時に Timeline 全体が再レンダーされないようにする
@@ -35,6 +36,7 @@ function TimelineTimecode() {
 function Timeline() {
   const {
     tracks,
+    crossTrackTransitions,
     pixelsPerSecond,
     duration,
     zoomIn,
@@ -181,6 +183,26 @@ function Timeline() {
             {tracks.map(track => (
               <Track key={track.id} track={track} />
             ))}
+
+            {crossTrackTransitions.map(ct => {
+              const sourceTrack = tracks.find(t => t.id === ct.sourceTrackId);
+              const targetTrack = tracks.find(t => t.id === ct.targetTrackId);
+              const sourceClip = sourceTrack?.clips.find(c => c.id === ct.sourceClipId);
+              const targetClip = targetTrack?.clips.find(c => c.id === ct.targetClipId);
+              if (!sourceClip || !targetClip) return null;
+              const sourceTrackIndex = tracks.findIndex(t => t.id === ct.sourceTrackId);
+              const targetTrackIndex = tracks.findIndex(t => t.id === ct.targetTrackId);
+              return (
+                <CrossTrackTransitionIndicator
+                  key={ct.id}
+                  transition={ct}
+                  sourceClip={sourceClip}
+                  targetClip={targetClip}
+                  sourceTrackIndex={sourceTrackIndex}
+                  targetTrackIndex={targetTrackIndex}
+                />
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -86,7 +86,10 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
   }
 
   const findTransitionAtTime = useCallback((time: number): TransitionInfo | null => {
-    const currentTracks = useTimelineStore.getState().tracks;
+    const state = useTimelineStore.getState();
+    const currentTracks = state.tracks;
+
+    // 1. 同一トラック内のトランジションをチェック
     for (const track of currentTracks) {
       if (track.type !== 'video') continue;
       for (const clip of track.clips) {
@@ -107,6 +110,37 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
         }
       }
     }
+
+    // 2. クロストラックトランジションをチェック
+    for (const ct of state.crossTrackTransitions) {
+      const sourceTrack = currentTracks.find(t => t.id === ct.sourceTrackId);
+      const targetTrack = currentTracks.find(t => t.id === ct.targetTrackId);
+      if (!sourceTrack || !targetTrack) continue;
+
+      const sourceClip = sourceTrack.clips.find(c => c.id === ct.sourceClipId);
+      const targetClip = targetTrack.clips.find(c => c.id === ct.targetClipId);
+      if (!sourceClip || !targetClip) continue;
+
+      // 重複区間を計算
+      const overlapStart = Math.max(sourceClip.startTime, targetClip.startTime);
+      const overlapEnd = Math.min(
+        sourceClip.startTime + sourceClip.duration,
+        targetClip.startTime + targetClip.duration,
+      );
+      // トランジション期間はdurationか重複区間の短い方
+      const transEnd = Math.min(overlapStart + ct.duration, overlapEnd);
+
+      if (time >= overlapStart && time < transEnd) {
+        const progress = (time - overlapStart) / (transEnd - overlapStart);
+        return {
+          outgoingClip: sourceClip,
+          incomingClip: targetClip,
+          progress,
+          transitionType: ct.type,
+        };
+      }
+    }
+
     return null;
   }, [findClipAtTime]);
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,7 +88,9 @@
     "wipeRight": "Wipe Right",
     "wipeUp": "Wipe Up",
     "wipeDown": "Wipe Down",
-    "duration": "Duration"
+    "duration": "Duration",
+    "crossTrack": "Cross-Track Transition",
+    "addCrossTrack": "Add Cross-Track Transition"
   },
   "preset": {
     "title": "Presets",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -88,7 +88,9 @@
     "wipeRight": "ワイプ右",
     "wipeUp": "ワイプ上",
     "wipeDown": "ワイプ下",
-    "duration": "時間"
+    "duration": "時間",
+    "crossTrack": "クロストラックトランジション",
+    "addCrossTrack": "クロストラックトランジション追加"
   },
   "preset": {
     "title": "プリセット",

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -98,20 +98,33 @@ export interface Track {
   clips: Clip[];
 }
 
+export interface CrossTrackTransition {
+  id: string;
+  type: TransitionType;
+  duration: number;
+  sourceTrackId: string;  // 出力元（フェードアウト側）
+  sourceClipId: string;
+  targetTrackId: string;  // 入力先（フェードイン側）
+  targetClipId: string;
+}
+
 export interface TimelineState {
   // タイムライン設定
   pixelsPerSecond: number;
   currentTime: number;
   duration: number;
   isPlaying: boolean;
-  
+
   // トラック
   tracks: Track[];
-  
+
+  // クロストラックトランジション
+  crossTrackTransitions: CrossTrackTransition[];
+
   // 選択状態
   selectedClipId: string | null;
   selectedTrackId: string | null;
-  
+
   // アクション
   setPixelsPerSecond: (pps: number) => void;
   setCurrentTime: (time: number) => void;
@@ -123,10 +136,15 @@ export interface TimelineState {
   removeTrack: (trackId: string) => void;
   zoomIn: () => void;
   zoomOut: () => void;
-  
+
   // トランジション
   setTransition: (trackId: string, clipId: string, transition: ClipTransition) => void;
   removeTransition: (trackId: string, clipId: string) => void;
+
+  // クロストラックトランジション
+  addCrossTrackTransition: (transition: CrossTrackTransition) => void;
+  removeCrossTrackTransition: (transitionId: string) => void;
+  updateCrossTrackTransition: (transitionId: string, updates: Partial<Pick<CrossTrackTransition, 'type' | 'duration'>>) => void;
 
   // カット編集機能
   setSelectedClip: (trackId: string | null, clipId: string | null) => void;
@@ -143,7 +161,10 @@ export const useTimelineStore = create<TimelineState>((set) => ({
   
   // トラック
   tracks: [],
-  
+
+  // クロストラックトランジション
+  crossTrackTransitions: [],
+
   // 選択状態
   selectedClipId: null,
   selectedTrackId: null,
@@ -176,6 +197,9 @@ export const useTimelineStore = create<TimelineState>((set) => ({
 
     return {
       tracks,
+      crossTrackTransitions: state.crossTrackTransitions.filter(
+        (ct) => ct.sourceClipId !== clipId && ct.targetClipId !== clipId
+      ),
       selectedTrackId: isSelectedClipRemoved ? null : state.selectedTrackId,
       selectedClipId: isSelectedClipRemoved ? null : state.selectedClipId,
     };
@@ -200,6 +224,9 @@ export const useTimelineStore = create<TimelineState>((set) => ({
   
   removeTrack: (trackId) => set((state) => ({
     tracks: state.tracks.filter(t => t.id !== trackId),
+    crossTrackTransitions: state.crossTrackTransitions.filter(
+      (ct) => ct.sourceTrackId !== trackId && ct.targetTrackId !== trackId
+    ),
   })),
   
   // ズーム
@@ -235,6 +262,39 @@ export const useTimelineStore = create<TimelineState>((set) => ({
             ),
           }
         : track
+    ),
+  })),
+
+  // クロストラックトランジション
+  addCrossTrackTransition: (transition) => set((state) => {
+    // バリデーション: 異なるトラックであること
+    if (transition.sourceTrackId === transition.targetTrackId) return state;
+
+    // バリデーション: クリップが存在し、時間的に重複していること
+    const sourceTrack = state.tracks.find(t => t.id === transition.sourceTrackId);
+    const targetTrack = state.tracks.find(t => t.id === transition.targetTrackId);
+    if (!sourceTrack || !targetTrack) return state;
+
+    const sourceClip = sourceTrack.clips.find(c => c.id === transition.sourceClipId);
+    const targetClip = targetTrack.clips.find(c => c.id === transition.targetClipId);
+    if (!sourceClip || !targetClip) return state;
+
+    const sourceEnd = sourceClip.startTime + sourceClip.duration;
+    const targetEnd = targetClip.startTime + targetClip.duration;
+    if (sourceClip.startTime >= targetEnd || targetClip.startTime >= sourceEnd) return state;
+
+    return {
+      crossTrackTransitions: [...state.crossTrackTransitions, transition],
+    };
+  }),
+
+  removeCrossTrackTransition: (transitionId) => set((state) => ({
+    crossTrackTransitions: state.crossTrackTransitions.filter(ct => ct.id !== transitionId),
+  })),
+
+  updateCrossTrackTransition: (transitionId, updates) => set((state) => ({
+    crossTrackTransitions: state.crossTrackTransitions.map(ct =>
+      ct.id === transitionId ? { ...ct, ...updates } : ct
     ),
   })),
 
@@ -286,23 +346,30 @@ export const useTimelineStore = create<TimelineState>((set) => ({
             }
           : t
       ),
+      crossTrackTransitions: state.crossTrackTransitions.filter(
+        (ct) => ct.sourceClipId !== clipId && ct.targetClipId !== clipId
+      ),
     };
   }),
   
   deleteSelectedClip: () => set((state) => {
     if (!state.selectedClipId || !state.selectedTrackId) return state;
 
+    const clipId = state.selectedClipId;
     return {
       tracks: state.tracks
         .map((track) =>
           track.id === state.selectedTrackId
             ? {
                 ...track,
-                clips: track.clips.filter((clip) => clip.id !== state.selectedClipId),
+                clips: track.clips.filter((clip) => clip.id !== clipId),
               }
             : track
         )
         .filter((track) => track.clips.length > 0),
+      crossTrackTransitions: state.crossTrackTransitions.filter(
+        (ct) => ct.sourceClipId !== clipId && ct.targetClipId !== clipId
+      ),
       selectedClipId: null,
       selectedTrackId: null,
     };

--- a/src/test/crossTrackTransition.test.ts
+++ b/src/test/crossTrackTransition.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTimelineStore } from '../store/timelineStore';
+import type { CrossTrackTransition } from '../store/timelineStore';
+
+describe('cross-track transition', () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [],
+      crossTrackTransitions: [],
+      selectedClipId: null,
+      selectedTrackId: null,
+      currentTime: 0,
+      isPlaying: false,
+      pixelsPerSecond: 50,
+    });
+
+    const { addTrack, addClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addTrack({ id: 'video-2', type: 'video', name: 'Video 2', clips: [] });
+
+    // Video 1: clip at 0-5s
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+    // Video 2: clip at 3-8s (overlaps with clip-1 from 3-5s)
+    addClip('video-2', {
+      id: 'clip-2',
+      name: 'Clip 2',
+      startTime: 3,
+      duration: 5,
+      filePath: 'b.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+  });
+
+  const makeCrossTransition = (overrides?: Partial<CrossTrackTransition>): CrossTrackTransition => ({
+    id: 'ct-1',
+    type: 'crossfade',
+    duration: 1.0,
+    sourceTrackId: 'video-1',
+    sourceClipId: 'clip-1',
+    targetTrackId: 'video-2',
+    targetClipId: 'clip-2',
+    ...overrides,
+  });
+
+  describe('addCrossTrackTransition', () => {
+    it('should add a cross-track transition between overlapping clips', () => {
+      const { addCrossTrackTransition } = useTimelineStore.getState();
+      addCrossTrackTransition(makeCrossTransition());
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(1);
+      expect(state.crossTrackTransitions[0].id).toBe('ct-1');
+      expect(state.crossTrackTransitions[0].type).toBe('crossfade');
+    });
+
+    it('should reject transition between clips on the same track', () => {
+      const { addCrossTrackTransition } = useTimelineStore.getState();
+      addCrossTrackTransition(makeCrossTransition({
+        sourceTrackId: 'video-1',
+        targetTrackId: 'video-1',
+      }));
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should reject transition between non-overlapping clips', () => {
+      // Add a non-overlapping clip on video-2
+      const { addClip, addCrossTrackTransition } = useTimelineStore.getState();
+      addClip('video-2', {
+        id: 'clip-3',
+        name: 'Clip 3',
+        startTime: 10,
+        duration: 5,
+        filePath: 'c.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      });
+
+      addCrossTrackTransition(makeCrossTransition({
+        targetClipId: 'clip-3',
+      }));
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should reject transition when clips do not exist', () => {
+      const { addCrossTrackTransition } = useTimelineStore.getState();
+      addCrossTrackTransition(makeCrossTransition({
+        sourceClipId: 'nonexistent',
+      }));
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+  });
+
+  describe('removeCrossTrackTransition', () => {
+    it('should remove a cross-track transition by id', () => {
+      const { addCrossTrackTransition, removeCrossTrackTransition } = useTimelineStore.getState();
+      addCrossTrackTransition(makeCrossTransition());
+      removeCrossTrackTransition('ct-1');
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+  });
+
+  describe('updateCrossTrackTransition', () => {
+    it('should update type and duration', () => {
+      const { addCrossTrackTransition, updateCrossTrackTransition } = useTimelineStore.getState();
+      addCrossTrackTransition(makeCrossTransition());
+      updateCrossTrackTransition('ct-1', { type: 'dissolve', duration: 2.0 });
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions[0].type).toBe('dissolve');
+      expect(state.crossTrackTransitions[0].duration).toBe(2.0);
+    });
+  });
+
+  describe('cascade deletion', () => {
+    beforeEach(() => {
+      const { addCrossTrackTransition } = useTimelineStore.getState();
+      addCrossTrackTransition(makeCrossTransition());
+    });
+
+    it('should remove cross-track transition when source clip is removed', () => {
+      const { removeClip } = useTimelineStore.getState();
+      removeClip('video-1', 'clip-1');
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should remove cross-track transition when target clip is removed', () => {
+      const { removeClip } = useTimelineStore.getState();
+      removeClip('video-2', 'clip-2');
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should remove cross-track transition when source track is removed', () => {
+      const { removeTrack } = useTimelineStore.getState();
+      removeTrack('video-1');
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should remove cross-track transition when target track is removed', () => {
+      const { removeTrack } = useTimelineStore.getState();
+      removeTrack('video-2');
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should remove cross-track transition when source clip is split', () => {
+      const { splitClipAtTime } = useTimelineStore.getState();
+      splitClipAtTime('video-1', 'clip-1', 2.5);
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should remove cross-track transition when selected clip is deleted', () => {
+      const { setSelectedClip, deleteSelectedClip } = useTimelineStore.getState();
+      setSelectedClip('video-1', 'clip-1');
+      deleteSelectedClip();
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(0);
+    });
+
+    it('should not remove unrelated cross-track transitions', () => {
+      // Add another clip and transition
+      const { addClip, addCrossTrackTransition, removeClip } = useTimelineStore.getState();
+      addClip('video-1', {
+        id: 'clip-3',
+        name: 'Clip 3',
+        startTime: 3,
+        duration: 5,
+        filePath: 'c.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      });
+      addCrossTrackTransition({
+        id: 'ct-2',
+        type: 'dissolve',
+        duration: 1.0,
+        sourceTrackId: 'video-1',
+        sourceClipId: 'clip-3',
+        targetTrackId: 'video-2',
+        targetClipId: 'clip-2',
+      });
+
+      // Remove clip-1 should only remove ct-1
+      removeClip('video-1', 'clip-1');
+
+      const state = useTimelineStore.getState();
+      expect(state.crossTrackTransitions).toHaveLength(1);
+      expect(state.crossTrackTransitions[0].id).toBe('ct-2');
+    });
+  });
+});

--- a/src/test/transitionExport.test.ts
+++ b/src/test/transitionExport.test.ts
@@ -122,3 +122,111 @@ describe('transition export data', () => {
     }
   });
 });
+
+describe('cross-track transition export data', () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [],
+      crossTrackTransitions: [],
+      selectedClipId: null,
+      selectedTrackId: null,
+      currentTime: 0,
+      isPlaying: false,
+      pixelsPerSecond: 50,
+    });
+
+    const { addTrack, addClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addTrack({ id: 'video-2', type: 'video', name: 'Video 2', clips: [] });
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+    addClip('video-2', {
+      id: 'clip-2',
+      name: 'Clip 2',
+      startTime: 3,
+      duration: 5,
+      filePath: 'b.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+  });
+
+  it('should serialize crossTrackTransitions for export', () => {
+    const { addCrossTrackTransition } = useTimelineStore.getState();
+    addCrossTrackTransition({
+      id: 'ct-1',
+      type: 'crossfade',
+      duration: 1.0,
+      sourceTrackId: 'video-1',
+      sourceClipId: 'clip-1',
+      targetTrackId: 'video-2',
+      targetClipId: 'clip-2',
+    });
+
+    const state = useTimelineStore.getState();
+    const exportSettings = {
+      format: 'mp4',
+      width: 1920,
+      height: 1080,
+      bitrate: '8M',
+      fps: 30,
+      outputPath: '/tmp/test.mp4',
+      tracks: state.tracks,
+      crossTrackTransitions: state.crossTrackTransitions,
+      totalDuration: 8,
+    };
+
+    const serialized = JSON.parse(JSON.stringify(exportSettings));
+    expect(serialized.crossTrackTransitions).toHaveLength(1);
+    expect(serialized.crossTrackTransitions[0]).toEqual({
+      id: 'ct-1',
+      type: 'crossfade',
+      duration: 1.0,
+      sourceTrackId: 'video-1',
+      sourceClipId: 'clip-1',
+      targetTrackId: 'video-2',
+      targetClipId: 'clip-2',
+    });
+  });
+
+  it('should serialize mixed same-track and cross-track transitions', () => {
+    const { setTransition, addCrossTrackTransition, addClip } = useTimelineStore.getState();
+
+    addClip('video-1', {
+      id: 'clip-3',
+      name: 'Clip 3',
+      startTime: 5,
+      duration: 5,
+      filePath: 'c.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+
+    // Same-track transition
+    setTransition('video-1', 'clip-3', { type: 'dissolve', duration: 0.5 });
+
+    // Cross-track transition
+    addCrossTrackTransition({
+      id: 'ct-1',
+      type: 'wipe-left',
+      duration: 1.5,
+      sourceTrackId: 'video-1',
+      sourceClipId: 'clip-1',
+      targetTrackId: 'video-2',
+      targetClipId: 'clip-2',
+    });
+
+    const state = useTimelineStore.getState();
+    const clip3 = state.tracks[0].clips.find(c => c.id === 'clip-3')!;
+    expect(clip3.transition).toEqual({ type: 'dissolve', duration: 0.5 });
+    expect(state.crossTrackTransitions).toHaveLength(1);
+    expect(state.crossTrackTransitions[0].type).toBe('wipe-left');
+  });
+});

--- a/src/test/transitionPlayback.test.ts
+++ b/src/test/transitionPlayback.test.ts
@@ -6,9 +6,12 @@ import { useTimelineStore, type TransitionType } from '../store/timelineStore';
  * VideoPreview内のヘルパー関数のロジックを再現してテスト
  */
 
-// findTransitionAtTime のロジックを再現
+// findTransitionAtTime のロジックを再現（同一トラック + クロストラック）
 function findTransitionAtTime(time: number) {
-  const tracks = useTimelineStore.getState().tracks;
+  const state = useTimelineStore.getState();
+  const tracks = state.tracks;
+
+  // 1. 同一トラック内のトランジション
   for (const track of tracks) {
     if (track.type !== 'video') continue;
     for (const clip of track.clips) {
@@ -38,6 +41,35 @@ function findTransitionAtTime(time: number) {
       }
     }
   }
+
+  // 2. クロストラックトランジション
+  for (const ct of state.crossTrackTransitions) {
+    const sourceTrack = tracks.find(t => t.id === ct.sourceTrackId);
+    const targetTrack = tracks.find(t => t.id === ct.targetTrackId);
+    if (!sourceTrack || !targetTrack) continue;
+
+    const sourceClip = sourceTrack.clips.find(c => c.id === ct.sourceClipId);
+    const targetClip = targetTrack.clips.find(c => c.id === ct.targetClipId);
+    if (!sourceClip || !targetClip) continue;
+
+    const overlapStart = Math.max(sourceClip.startTime, targetClip.startTime);
+    const overlapEnd = Math.min(
+      sourceClip.startTime + sourceClip.duration,
+      targetClip.startTime + targetClip.duration,
+    );
+    const transEnd = Math.min(overlapStart + ct.duration, overlapEnd);
+
+    if (time >= overlapStart && time < transEnd) {
+      const progress = (time - overlapStart) / (transEnd - overlapStart);
+      return {
+        outgoingClip: sourceClip,
+        incomingClip: targetClip,
+        progress,
+        transitionType: ct.type,
+      };
+    }
+  }
+
   return null;
 }
 
@@ -192,5 +224,94 @@ describe('transition playback logic', () => {
       expect(styles.outgoing.opacity).toBeCloseTo(0.5);
       expect(styles.incoming.opacity).toBeCloseTo(0.5);
     });
+  });
+});
+
+describe('cross-track transition playback logic', () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [],
+      crossTrackTransitions: [],
+      selectedClipId: null,
+      selectedTrackId: null,
+      currentTime: 0,
+      isPlaying: false,
+      pixelsPerSecond: 50,
+    });
+
+    const { addTrack, addClip, addCrossTrackTransition } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addTrack({ id: 'video-2', type: 'video', name: 'Video 2', clips: [] });
+
+    // Video 1: clip at 0-5s
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+    // Video 2: clip at 3-8s (overlaps with clip-1 from 3-5s)
+    addClip('video-2', {
+      id: 'clip-2',
+      name: 'Clip 2',
+      startTime: 3,
+      duration: 5,
+      filePath: 'b.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+
+    addCrossTrackTransition({
+      id: 'ct-1',
+      type: 'crossfade',
+      duration: 1.5,
+      sourceTrackId: 'video-1',
+      sourceClipId: 'clip-1',
+      targetTrackId: 'video-2',
+      targetClipId: 'clip-2',
+    });
+  });
+
+  it('should return null before cross-track transition zone', () => {
+    expect(findTransitionAtTime(2.9)).toBeNull();
+  });
+
+  it('should detect cross-track transition at overlap start', () => {
+    const result = findTransitionAtTime(3.0);
+    expect(result).not.toBeNull();
+    expect(result!.outgoingClip.id).toBe('clip-1');
+    expect(result!.incomingClip.id).toBe('clip-2');
+    expect(result!.progress).toBeCloseTo(0);
+    expect(result!.transitionType).toBe('crossfade');
+  });
+
+  it('should compute progress correctly at midpoint', () => {
+    // duration=1.5, overlapStart=3.0, transEnd=4.5
+    const result = findTransitionAtTime(3.75);
+    expect(result).not.toBeNull();
+    expect(result!.progress).toBeCloseTo(0.5);
+  });
+
+  it('should return null after cross-track transition zone', () => {
+    // transEnd = 3.0 + 1.5 = 4.5
+    expect(findTransitionAtTime(4.5)).toBeNull();
+  });
+
+  it('should cap transition duration to overlap region', () => {
+    // Set a very long duration (10s) but overlap is only 2s (3-5)
+    const { updateCrossTrackTransition } = useTimelineStore.getState();
+    updateCrossTrackTransition('ct-1', { duration: 10 });
+
+    // At time 4.0, should be detected (within overlap 3-5)
+    const result = findTransitionAtTime(4.0);
+    expect(result).not.toBeNull();
+    // progress = (4.0 - 3.0) / (5.0 - 3.0) = 0.5
+    expect(result!.progress).toBeCloseTo(0.5);
+
+    // At time 5.0 (outside overlap), should return null
+    expect(findTransitionAtTime(5.0)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- 異なるトラックに配置されたクリップ間にトランジション（クロスフェード、ディゾルブ、ワイプ等）を適用できるようにした
- 既存の同一トラック内トランジションはそのまま維持し、新しい `CrossTrackTransition` エンティティとして実装
- プレビュー再生・FFmpegエクスポートの両方に対応

Closes #51

## 変更内容

### データモデル・ストア (`timelineStore.ts`)
- `CrossTrackTransition` 型を追加（id, type, duration, sourceTrackId/ClipId, targetTrackId/ClipId）
- `addCrossTrackTransition` / `removeCrossTrackTransition` / `updateCrossTrackTransition` アクションを追加
- バリデーション: 同一トラック拒否、時間的重複なしのクリップ拒否
- クリップ・トラック削除時のカスケード削除

### UI
- `CrossTrackTransitionIndicator` コンポーネント新規作成（青色で同一トラックと区別）
- クリップ右クリックメニューに「クロストラックトランジション追加」サブメニューを追加
- インジケータークリックでタイプ・duration編集ポップオーバー表示

### プレビュー再生 (`VideoPreview.tsx`)
- `findTransitionAtTime` をクロストラック対応に拡張

### エクスポート (`export.rs`)
- `ExportCrossTrackTransition` 構造体追加
- クロストラックトランジション用の xfade/acrossfade フィルター生成

### テスト
- ユニットテスト20件追加（ストア操作13件、プレビュー再生5件、エクスポート2件）

## 手動テスト手順
- [x] 異なるトラックに2つのビデオクリップを配置し、時間的に重複させる
- [x] 重複しているクリップを右クリック →「クロストラックトランジション追加」サブメニューが表示される
- [x] サブメニューから対象クリップを選択 → 青色のインジケーターがトラック間に表示される
- [x] インジケーターをクリック → ポップオーバーでタイプ・duration を変更できる
- [x] プレビュー再生でトランジション効果が確認できる
- [x] インジケーター右クリック → 削除できる
- [x] ソース/ターゲットクリップを削除 → クロストラックトランジションも連動削除される
- [ ] エクスポートが正常に完了する