### PR TITLE
CIのNode.jsバージョンを25に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '25'
           cache: 'npm'
       
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '25'
           cache: 'npm'
       
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '25'
           cache: 'npm'
       
       - name: Install dependencies
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '25'
           cache: 'npm'
       
       - name: Install dependencies
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '25'
           cache: 'npm'
       
       - name: Setup Rust


### PR DESCRIPTION
## Summary
- ローカル環境のNode.js 25.8.0に合わせて、CIの全ジョブのnode-versionを22から25に更新

## 変更内容
- ci.ymlの全5ジョブ(lint, test, audit, build, build-tauri)のnode-versionを`22`→`25`に変更

## 手動テスト手順
- [ ] CIの各ジョブが正常に動作すること
- [ ] ローカルで`npm run lint`が通ること
- [ ] ローカルで`npm run build`が通ること