### PR TITLE
Node 25環境でテストが失敗する問題を修正

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -15,7 +15,9 @@ const resources = {
 
 // ブラウザの言語設定を取得（デフォルトは日本語）
 const detectLanguage = (): string => {
-  const saved = localStorage.getItem('i18n-language');
+  const saved = typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function'
+    ? localStorage.getItem('i18n-language')
+    : null;
   if (saved) return saved;
 
   const browserLang = navigator.language.startsWith('ja') ? 'ja' : 'en';


### PR DESCRIPTION
## Summary
- Node 25のhappy-dom環境で`localStorage.getItem`が関数として提供されず、i18nモジュール読み込み時にTypeErrorが発生しテストが全件失敗していた問題を修正

## 変更内容
- `src/i18n.ts`の`detectLanguage`内で`localStorage`の存在と`getItem`が関数であることをチェックしてからアクセスするように変更

## 手動テスト手順
- [x] `npm run test`で全テストがパスすること
- [x] `npm run lint`がエラーなしで通ること
- [x] `npm run build`が成功すること
- [x] アプリ起動時に言語切り替えが正常に動作すること