### PR TITLE
タグプッシュによるリリース自動化ワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  quality-gate:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '25'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Run npm audit
+        run: npm audit --audit-level=moderate
+
+  release:
+    name: Release (${{ matrix.platform }})
+    needs: quality-gate
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            args: ''
+          - platform: macos-latest
+            args: '--target aarch64-apple-darwin'
+          - platform: windows-latest
+            args: ''
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '25'
+          cache: 'npm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: 'qcut ${{ github.ref_name }}'
+          releaseBody: 'See the assets below to download and install this version.'
+          releaseDraft: ${{ contains(github.ref_name, '-beta') }}
+          prerelease: ${{ contains(github.ref_name, '-beta') }}
+          args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary
- `v*` タグのpushで macOS / Windows / Linux 向け Tauri ビルドを実行し、GitHub Release を自動作成
- タグ名に `-beta` を含む場合は draft + prerelease としてリリース
- リリース前に lint / test / audit の quality gate を実行

## 使い方
```bash
# 正式リリース
git tag v0.1.0 && git push origin v0.1.0

# betaリリース（draftになる）
git tag v0.1.0-beta.1 && git push origin v0.1.0-beta.1
```

## 手動テスト
- [ ] ワークフローファイルの構文が正しいこと（マージ後にGitHub Actionsで確認）
- [ ] テスト用betaタグ（例: `v0.1.0-beta.1`）をpushしてdraftリリースが作成されること
- [ ] 3プラットフォーム（macOS, Windows, Linux）のビルドが成功すること