### PR TITLE
音声波形表示機能を追加

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,7 @@ export default [
         HTMLDivElement: 'readonly',
         HTMLVideoElement: 'readonly',
         HTMLInputElement: 'readonly',
+        HTMLCanvasElement: 'readonly',
         KeyboardEvent: 'readonly',
         File: 'readonly',
         URL: 'readonly',

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod files;
 pub mod plugins;
 pub mod export;
 pub mod presets;
+pub mod waveform;
 

--- a/src-tauri/src/commands/waveform.rs
+++ b/src-tauri/src/commands/waveform.rs
@@ -1,0 +1,118 @@
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::Mutex;
+
+pub struct WaveformCache {
+    pub cache: Mutex<HashMap<String, Vec<[f32; 2]>>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaveformData {
+    pub peaks: Vec<[f32; 2]>,
+    pub sample_rate: u32,
+    pub source_duration: f64,
+}
+
+const PEAKS_PER_SECOND: u32 = 1000;
+const SAMPLES_PER_PEAK: u32 = 256;
+
+#[tauri::command]
+pub async fn get_waveform(
+    file_path: String,
+    cache: tauri::State<'_, WaveformCache>,
+) -> Result<WaveformData, String> {
+    // キャッシュ確認
+    {
+        let c = cache.cache.lock().map_err(|e| e.to_string())?;
+        if let Some(peaks) = c.get(&file_path) {
+            let duration = peaks.len() as f64 / PEAKS_PER_SECOND as f64;
+            return Ok(WaveformData {
+                peaks: peaks.clone(),
+                sample_rate: PEAKS_PER_SECOND,
+                source_duration: duration,
+            });
+        }
+    }
+
+    let decode_rate = PEAKS_PER_SECOND * SAMPLES_PER_PEAK;
+
+    let mut child = Command::new("ffmpeg")
+        .args([
+            "-i",
+            &file_path,
+            "-f",
+            "f32le",
+            "-ac",
+            "1",
+            "-ar",
+            &decode_rate.to_string(),
+            "-v",
+            "quiet",
+            "pipe:1",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("FFmpeg起動失敗: {}", e))?;
+
+    let stdout = child.stdout.take().ok_or("stdout取得失敗")?;
+    let mut reader = std::io::BufReader::new(stdout);
+
+    let mut peaks: Vec<[f32; 2]> = Vec::new();
+    let chunk_bytes = SAMPLES_PER_PEAK as usize * 4; // f32 = 4 bytes
+    let mut buf = vec![0u8; chunk_bytes];
+
+    loop {
+        let mut total_read = 0;
+        while total_read < buf.len() {
+            match reader.read(&mut buf[total_read..]) {
+                Ok(0) => break,
+                Ok(n) => total_read += n,
+                Err(_) => break,
+            }
+        }
+        if total_read == 0 {
+            break;
+        }
+
+        let sample_count = total_read / 4;
+        let mut min_val: f32 = 0.0;
+        let mut max_val: f32 = 0.0;
+
+        for i in 0..sample_count {
+            let bytes = [
+                buf[i * 4],
+                buf[i * 4 + 1],
+                buf[i * 4 + 2],
+                buf[i * 4 + 3],
+            ];
+            let sample = f32::from_le_bytes(bytes);
+            if sample < min_val {
+                min_val = sample;
+            }
+            if sample > max_val {
+                max_val = sample;
+            }
+        }
+        peaks.push([min_val, max_val]);
+    }
+
+    let _ = child.wait();
+
+    // キャッシュに保存
+    {
+        let mut c = cache.cache.lock().map_err(|e| e.to_string())?;
+        c.insert(file_path.clone(), peaks.clone());
+    }
+
+    let duration = peaks.len() as f64 / PEAKS_PER_SECOND as f64;
+    Ok(WaveformData {
+        peaks,
+        sample_rate: PEAKS_PER_SECOND,
+        source_duration: duration,
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -6,6 +7,9 @@ pub fn run() {
   tauri::Builder::default()
     .manage(commands::export::ExportState {
       cancel_flag: Arc::new(AtomicBool::new(false)),
+    })
+    .manage(commands::waveform::WaveformCache {
+      cache: std::sync::Mutex::new(HashMap::new()),
     })
     .plugin(tauri_plugin_dialog::init())
     .setup(|app| {
@@ -32,6 +36,7 @@ pub fn run() {
       commands::export::cancel_export,
       commands::presets::read_transition_presets,
       commands::presets::write_transition_presets,
+      commands::waveform::get_waveform,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -3,13 +3,15 @@ import { useVideoPreviewStore } from '../../store/videoPreviewStore';
 import { useTransitionPresetStore } from '../../store/transitionPresetStore';
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { WaveformCanvas } from './WaveformCanvas';
 
 interface ClipProps {
   clip: ClipType;
   trackId: string;
+  trackType: 'video' | 'audio' | 'text';
 }
 
-function Clip({ clip, trackId }: ClipProps) {
+function Clip({ clip, trackId, trackType }: ClipProps) {
   const { t } = useTranslation();
   const {
     pixelsPerSecond,
@@ -175,6 +177,16 @@ function Clip({ clip, trackId }: ClipProps) {
         onContextMenu={handleContextMenu}
         title={clip.name}
       >
+        {clip.filePath && trackType !== 'text' && (
+          <WaveformCanvas
+            filePath={clip.filePath}
+            sourceStartTime={clip.sourceStartTime}
+            sourceEndTime={clip.sourceEndTime}
+            width={width}
+            height={48}
+            color={trackType === 'audio' ? '#a0cfff' : 'rgba(160, 207, 255, 0.4)'}
+          />
+        )}
         <div className="clip-content">
           <span className="clip-name">{clip.name}</span>
           <button className="clip-delete" onClick={handleDelete}>×</button>

--- a/src/components/Timeline/Timeline.css
+++ b/src/components/Timeline/Timeline.css
@@ -194,6 +194,8 @@
 }
 
 .clip-content {
+  position: relative;
+  z-index: 1;
   padding: 0.5rem;
   height: 100%;
   display: flex;

--- a/src/components/Timeline/Track.tsx
+++ b/src/components/Timeline/Track.tsx
@@ -11,7 +11,7 @@ function Track({ track }: TrackProps) {
     <div className="timeline-track" data-track-id={track.id} data-track-type={track.type}>
       <div className="timeline-track-content">
         {track.clips.map(clip => (
-          <Clip key={clip.id} clip={clip} trackId={track.id} />
+          <Clip key={clip.id} clip={clip} trackId={track.id} trackType={track.type} />
         ))}
         {track.clips
           .filter(clip => clip.transition)

--- a/src/components/Timeline/WaveformCanvas.tsx
+++ b/src/components/Timeline/WaveformCanvas.tsx
@@ -1,0 +1,81 @@
+import { useRef, useEffect } from 'react';
+import { useWaveformStore } from '../../store/waveformStore';
+
+interface WaveformCanvasProps {
+  filePath: string;
+  sourceStartTime: number;
+  sourceEndTime: number;
+  width: number;
+  height: number;
+  color?: string;
+}
+
+export const WaveformCanvas: React.FC<WaveformCanvasProps> = ({ filePath, sourceStartTime, sourceEndTime, width, height, color = '#a0cfff' }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const waveformData = useWaveformStore((s) => s.waveforms[filePath]);
+  const fetchWaveform = useWaveformStore((s) => s.fetchWaveform);
+
+  useEffect(() => {
+    if (filePath) {
+      fetchWaveform(filePath);
+    }
+  }, [filePath, fetchWaveform]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !waveformData || width <= 0) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, height);
+
+    const { peaks, sampleRate } = waveformData;
+    const startIndex = Math.floor(sourceStartTime * sampleRate);
+    const endIndex = Math.ceil(sourceEndTime * sampleRate);
+    const slicedPeaks = peaks.slice(startIndex, endIndex);
+
+    if (slicedPeaks.length === 0) return;
+
+    const centerY = height / 2;
+    ctx.fillStyle = color;
+
+    const peaksPerPixel = slicedPeaks.length / width;
+
+    for (let x = 0; x < width; x++) {
+      const fromIdx = Math.floor(x * peaksPerPixel);
+      const toIdx = Math.min(Math.floor((x + 1) * peaksPerPixel), slicedPeaks.length);
+
+      let min = 0;
+      let max = 0;
+      for (let j = fromIdx; j < toIdx; j++) {
+        if (slicedPeaks[j][0] < min) min = slicedPeaks[j][0];
+        if (slicedPeaks[j][1] > max) max = slicedPeaks[j][1];
+      }
+
+      const top = centerY - max * centerY;
+      const bottom = centerY - min * centerY;
+      const barHeight = Math.max(1, bottom - top);
+
+      ctx.fillRect(x, top, 1, barHeight);
+    }
+  }, [waveformData, sourceStartTime, sourceEndTime, width, height, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+};

--- a/src/store/waveformStore.ts
+++ b/src/store/waveformStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+
+interface WaveformData {
+  peaks: [number, number][];
+  sampleRate: number;
+  sourceDuration: number;
+}
+
+interface WaveformState {
+  waveforms: Record<string, WaveformData>;
+  loading: Record<string, boolean>;
+  fetchWaveform: (filePath: string) => Promise<void>;
+}
+
+export const useWaveformStore = create<WaveformState>((set, get) => ({
+  waveforms: {},
+  loading: {},
+
+  fetchWaveform: async (filePath: string) => {
+    const state = get();
+    if (state.waveforms[filePath] || state.loading[filePath]) return;
+
+    set((s) => ({ loading: { ...s.loading, [filePath]: true } }));
+
+    try {
+      const data = await invoke<WaveformData>('get_waveform', { filePath });
+      set((s) => ({
+        waveforms: { ...s.waveforms, [filePath]: data },
+        loading: { ...s.loading, [filePath]: false },
+      }));
+    } catch (err) {
+      console.error('Waveform fetch failed:', filePath, err);
+      set((s) => ({ loading: { ...s.loading, [filePath]: false } }));
+    }
+  },
+}));

--- a/src/test/waveformStore.test.ts
+++ b/src/test/waveformStore.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+import { useWaveformStore } from '../store/waveformStore';
+import { invoke } from '@tauri-apps/api/core';
+
+describe('waveformStore', () => {
+  beforeEach(() => {
+    useWaveformStore.setState({ waveforms: {}, loading: {} });
+    vi.clearAllMocks();
+  });
+
+  it('should fetch waveform and cache it', async () => {
+    const mockData = {
+      peaks: [[-0.5, 0.5], [-0.3, 0.7]] as [number, number][],
+      sampleRate: 1000,
+      sourceDuration: 0.002,
+    };
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
+
+    await useWaveformStore.getState().fetchWaveform('/test/audio.mp3');
+
+    expect(invoke).toHaveBeenCalledWith('get_waveform', { filePath: '/test/audio.mp3' });
+    expect(useWaveformStore.getState().waveforms['/test/audio.mp3']).toEqual(mockData);
+    expect(useWaveformStore.getState().loading['/test/audio.mp3']).toBe(false);
+  });
+
+  it('should not refetch if already cached', async () => {
+    useWaveformStore.setState({
+      waveforms: { '/test/audio.mp3': { peaks: [], sampleRate: 1000, sourceDuration: 0 } },
+    });
+
+    await useWaveformStore.getState().fetchWaveform('/test/audio.mp3');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('should not refetch if already loading', async () => {
+    useWaveformStore.setState({ loading: { '/test/audio.mp3': true } });
+
+    await useWaveformStore.getState().fetchWaveform('/test/audio.mp3');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetch errors gracefully', async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('FFmpeg not found'));
+
+    await useWaveformStore.getState().fetchWaveform('/test/bad.mp3');
+
+    expect(useWaveformStore.getState().waveforms['/test/bad.mp3']).toBeUndefined();
+    expect(useWaveformStore.getState().loading['/test/bad.mp3']).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #66
- タイムライン上の音声/動画クリップに波形（Waveform）を表示する機能を追加
- Rust側でFFmpegを使いPCMデコード→ピーク値抽出、フロントエンドでCanvas 2D描画

## 変更内容
- **Rust**: `get_waveform` Tauriコマンド追加（FFmpegでf32le PCMデコード、256サンプルごとにmin/max計算、in-memoryキャッシュ）
- **フロントエンド**: `waveformStore`（Zustand）で波形データ取得・キャッシュ管理
- **WaveformCanvas**: Canvas 2Dで波形描画（devicePixelRatio対応、ズーム連動）
- **Clip/Track統合**: 音声トラックは `#a0cfff`、動画トラックは半透明で波形表示
- **ESLint**: `HTMLCanvasElement` をglobalsに追加
- **テスト**: waveformStoreのユニットテスト4件追加

## 手打鍵
- [x] 音声ファイル（mp3等）をインポートし、タイムライン上のクリップに波形が表示されることを確認
- [x] 動画ファイルをインポートし、動画クリップにも薄い波形が表示されることを確認
- [x] ズームイン/アウトで波形が追従して再描画されることを確認
- [x] 同じファイルを複数回インポートしてもキャッシュが効き再取得されないことを確認
- [x] FFmpegが無い環境でエラーが出ても波形なしで正常動作することを確認