### PR TITLE
プレビュー再生時に音声フェードイン/フェードアウトを反映

### DIFF
--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -419,10 +419,24 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
             videoRef.current.style.opacity = '1';
           }
 
-          // クリップの音量エフェクトを適用
+          // クリップの音量エフェクトを適用（フェードイン/アウトも反映）
           const clipVolume = clip.effects?.volume ?? 1.0;
           const uiVolume = useVideoPreviewStore.getState().volume / 100;
-          videoRef.current.volume = Math.max(0, Math.min(1, uiVolume * clipVolume));
+          const audioFadeIn = clip.effects?.fadeIn ?? 0;
+          const audioFadeOut = clip.effects?.fadeOut ?? 0;
+          let audioFade = 1;
+          if (audioFadeIn > 0 || audioFadeOut > 0) {
+            const elapsedTime = currentTimeRef.current - clip.startTime;
+            const remainingTime = clipEndTime - currentTimeRef.current;
+            if (audioFadeIn > 0 && elapsedTime < audioFadeIn) {
+              audioFade = Math.min(audioFade, elapsedTime / audioFadeIn);
+            }
+            if (audioFadeOut > 0 && remainingTime < audioFadeOut) {
+              audioFade = Math.min(audioFade, remainingTime / audioFadeOut);
+            }
+            audioFade = Math.max(0, Math.min(1, audioFade));
+          }
+          videoRef.current.volume = Math.max(0, Math.min(1, uiVolume * clipVolume * audioFade));
         }
       } else {
         // --- ギャップ区間 ---


### PR DESCRIPTION
## Summary
- プレビュー再生時にクリップのfadeIn/fadeOut設定が音声にも反映されるようにした
- 映像のopacityフェードと連動して音量が滑らかに変化する

Closes #65

## Test plan
- [x] ビデオクリップにフェードイン（例: 1.5秒）を設定し、プレビュー再生でクリップ開始時に音声が徐々に大きくなることを確認
- [x] ビデオクリップにフェードアウト（例: 1.5秒）を設定し、プレビュー再生でクリップ終了前に音声が徐々に小さくなることを確認
- [x] フェードイン・フェードアウト両方を設定し、映像のopacityと音量が同期して変化することを確認
- [x] フェード未設定時に音量が従来通り正常に動作することを確認
- [x] 音量スライダー（UI音量）とクリップ音量エフェクトとフェードが正しく掛け合わされることを確認