### PR TITLE
動画プレビューのレスポンシブレイアウト対応

### DIFF
--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -11,7 +11,7 @@ interface VideoPreviewProps {
 
 export const VideoPreview: React.FC<VideoPreviewProps> = ({
   width = '100%',
-  height = '400px',
+  height = '100%',
 }) => {
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -740,10 +740,11 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
         height,
         flex: 1,
         minWidth: 0,
+        minHeight: 0,
         display: 'flex',
         flexDirection: 'column',
-        gap: '12px',
-        padding: '12px',
+        gap: '8px',
+        padding: '8px',
         backgroundColor: '#1a1a1a',
       }}
     >


### PR DESCRIPTION
## Summary
- 動画プレビューのデフォルト高さを固定値(400px)から100%に変更し、ウィンドウサイズに追従するように修正
- プレビューとタイムライン間の不要な隙間を解消

## Test plan
- [x] ウィンドウサイズを変更して動画プレビュー領域が追従してリサイズされることを確認
- [x] 動画プレビューとタイムラインの間に不要な隙間がないことを確認
- [x] 動画の再生・停止が正常に動作することを確認
- [x] テキストオーバーレイが正しく表示されることを確認