### PR TITLE
クリップ選択がマウスを離すと解除されるバグを修正

### DIFF
--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -86,17 +86,18 @@ function Timeline() {
       panStartX.current = e.clientX;
       panStartScrollLeft.current = timelineContainerRef.current?.scrollLeft || 0;
     }
+
+    // クリップ以外の場所をクリックした場合は選択解除
+    // mousedown で処理する（click だと isDragging の再レンダーで e.target がずれるため）
+    if (!(e.target as HTMLElement).closest('.timeline-clip') &&
+        (e.target === e.currentTarget || (e.target as HTMLElement).closest('.timeline-tracks'))) {
+      setSelectedClip(null, null);
+    }
   };
 
   const handleTimelineClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // パンニング中はクリック処理をしない
     if (isPanning) return;
-
-    // クリップ以外の場所をクリックした場合は選択解除
-    if (!(e.target as HTMLElement).closest('.timeline-clip') &&
-        (e.target === e.currentTarget || (e.target as HTMLElement).closest('.timeline-tracks'))) {
-      setSelectedClip(null, null);
-    }
 
     // ルーラー領域のクリックのみシーク（トラック領域ではシークしない）
     if ((e.target as HTMLElement).closest('.timeline-ruler')) {


### PR DESCRIPTION
## Summary
- クリップをクリックで選択後、マウスを離すと選択が解除されるバグを修正
- 選択解除の判定を `onClick` から `onMouseDown` に移動

## 原因
ログ調査で判明：
1. `mousedown` → `setIsDragging(true)` → クリップ選択
2. `mouseup` → `setIsDragging(false)` → 再レンダー発生
3. 再レンダーにより `click` イベントの `e.target` が `.timeline-clip` ではなく `.timeline-track-content` を指す
4. Clip の `stopPropagation` が発火せず、Timeline の `handleTimelineClick` で `setSelectedClip(null, null)` が実行される

## 手動テスト手順
- [x] クリップをクリックして選択状態が維持されることを確認
- [x] クリップ以外のタイムライン空白部分をクリックすると選択解除されることを確認
- [x] クリップをドラッグ移動しても選択状態が維持されることを確認
- [x] 右クリックのコンテキストメニューが正常に動作することを確認