### PR TITLE
クリップドラッグ移動後のundoが中間位置を経由する問題を修正

### DIFF
--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -19,7 +19,8 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
     setSelectedClip,
     selectedClipId,
     splitClipAtTime,
-    updateClip,
+    updateClipSilent,
+    commitHistory,
     setTransition,
     removeTransition,
     moveClipToTrack,
@@ -70,7 +71,7 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
       const deltaTime = deltaX / pixelsPerSecond;
       let newStartTime = dragStartTime.current + deltaTime;
       newStartTime = Math.max(0, newStartTime);
-      updateClip(currentTrackId, clip.id, { startTime: newStartTime });
+      updateClipSilent(currentTrackId, clip.id, { startTime: newStartTime });
 
       // 垂直方向: ドロップ先トラックの判定
       const trackEl = document.elementFromPoint(e.clientX, e.clientY)?.closest('.timeline-track') as HTMLElement | null;
@@ -91,6 +92,7 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
 
     const handleMouseUp = () => {
       document.querySelectorAll('.timeline-track.drop-target').forEach(el => el.classList.remove('drop-target'));
+      commitHistory();
       setIsDragging(false);
     };
 
@@ -101,7 +103,7 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [isDragging, pixelsPerSecond, trackId, clip.id, updateClip, moveClipToTrack]);
+  }, [isDragging, pixelsPerSecond, trackId, clip.id, updateClipSilent, commitHistory, moveClipToTrack]);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -135,6 +135,8 @@ export interface TimelineState {
   addClip: (trackId: string, clip: Clip) => void;
   removeClip: (trackId: string, clipId: string) => void;
   updateClip: (trackId: string, clipId: string, updates: Partial<Clip>) => void;
+  updateClipSilent: (trackId: string, clipId: string, updates: Partial<Clip>) => void;
+  commitHistory: () => void;
   addTrack: (track: Track) => void;
   removeTrack: (trackId: string) => void;
   moveClipToTrack: (fromTrackId: string, clipId: string, toTrackId: string) => void;
@@ -242,6 +244,27 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
         : track
     );
     return withHistory(state, newTracks);
+  }),
+
+  updateClipSilent: (trackId, clipId, updates) => set((state) => {
+    const newTracks = state.tracks.map(track =>
+      track.id === trackId
+        ? {
+            ...track,
+            clips: track.clips.map(clip =>
+              clip.id === clipId ? { ...clip, ...updates } : clip
+            ),
+          }
+        : track
+    );
+    return { tracks: newTracks };
+  }),
+
+  commitHistory: () => set((state) => {
+    const history = state._history.slice(0, state._historyIndex + 1);
+    history.push(JSON.parse(JSON.stringify(state.tracks)));
+    if (history.length > MAX_HISTORY) history.shift();
+    return { _history: history, _historyIndex: history.length - 1 };
   }),
 
   addTrack: (track) => set((state) =>


### PR DESCRIPTION
## Summary
- ドラッグ中の `mousemove` ごとに履歴スナップショットが作成され、undo が中間位置を1ステップずつ戻る問題を修正
- `updateClipSilent`（履歴なし更新）と `commitHistory`（手動履歴記録）を追加し、ドロップ時に1回だけ履歴を記録するように変更

Closes #81

## 手打鍵手順
- [x] クリップを水平方向にドラッグ移動する
- [x] ドロップ後に Ctrl+Z（macOS: Cmd+Z）を押す
- [x] ドラッグ開始位置に一発で戻ることを確認
- [x] Ctrl+Y（macOS: Cmd+Shift+Z）で redo し、ドロップ位置に戻ることを確認
- [x] クリップを別トラックにドラッグ移動し、undo で元のトラック・位置に戻ることを確認