### PR TITLE
プロジェクトファイル(.qcut)のスキーマ定義を追加

### DIFF
--- a/src/test/projectFile.test.ts
+++ b/src/test/projectFile.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import type { ProjectFile } from '../types/projectFile';
+import { CURRENT_SCHEMA_VERSION } from '../types/projectFile';
+
+describe('ProjectFile schema', () => {
+  const validProject: ProjectFile = {
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    appVersion: '0.1.0',
+    createdAt: '2026-03-08T12:00:00.000Z',
+    updatedAt: '2026-03-08T12:00:00.000Z',
+    metadata: {
+      name: 'テストプロジェクト',
+    },
+    timeline: {
+      tracks: [
+        {
+          id: 'track-1',
+          type: 'video',
+          name: 'Video 1',
+          volume: 1.0,
+          mute: false,
+          solo: false,
+          clips: [
+            {
+              id: 'clip-1',
+              name: 'sample.mp4',
+              startTime: 0,
+              duration: 10,
+              filePath: 'media/sample.mp4',
+              sourceStartTime: 0,
+              sourceEndTime: 10,
+            },
+          ],
+        },
+        {
+          id: 'track-2',
+          type: 'audio',
+          name: 'Audio 1',
+          volume: 0.8,
+          mute: false,
+          solo: false,
+          clips: [],
+        },
+        {
+          id: 'track-3',
+          type: 'text',
+          name: 'Text 1',
+          volume: 1.0,
+          mute: false,
+          solo: false,
+          clips: [
+            {
+              id: 'clip-2',
+              name: 'テロップ',
+              startTime: 2,
+              duration: 3,
+              filePath: '',
+              sourceStartTime: 0,
+              sourceEndTime: 3,
+              textProperties: {
+                text: 'Hello',
+                fontSize: 32,
+                fontColor: '#ffffff',
+                fontFamily: 'sans-serif',
+                bold: false,
+                italic: false,
+                textAlign: 'center',
+                positionX: 50,
+                positionY: 85,
+                opacity: 1,
+                backgroundColor: 'transparent',
+                animation: 'none',
+                animationDuration: 0.3,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    exportSettings: {
+      format: 'mp4',
+      width: 1920,
+      height: 1080,
+      bitrate: '8M',
+      fps: 30,
+    },
+  };
+
+  it('CURRENT_SCHEMA_VERSION が 1 である', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(1);
+  });
+
+  it('有効なプロジェクトファイルが型に適合する', () => {
+    expect(validProject.schemaVersion).toBe(1);
+    expect(validProject.appVersion).toBe('0.1.0');
+    expect(validProject.metadata.name).toBe('テストプロジェクト');
+    expect(validProject.timeline.tracks).toHaveLength(3);
+  });
+
+  it('タイムラインのトラック型が正しい', () => {
+    const types = validProject.timeline.tracks.map((t) => t.type);
+    expect(types).toEqual(['video', 'audio', 'text']);
+  });
+
+  it('クリップにエフェクト・テキスト・トランジションがオプショナルで設定できる', () => {
+    const videoClip = validProject.timeline.tracks[0].clips[0];
+    expect(videoClip.effects).toBeUndefined();
+    expect(videoClip.transition).toBeUndefined();
+
+    const textClip = validProject.timeline.tracks[2].clips[0];
+    expect(textClip.textProperties).toBeDefined();
+    expect(textClip.textProperties?.text).toBe('Hello');
+  });
+
+  it('エフェクト付きクリップが型に適合する', () => {
+    const clipWithEffects: ProjectFile['timeline']['tracks'][0]['clips'][0] = {
+      id: 'clip-fx',
+      name: 'effects.mp4',
+      startTime: 0,
+      duration: 5,
+      filePath: 'media/effects.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+      effects: {
+        brightness: 1.2,
+        contrast: 1.0,
+        saturation: 0.8,
+        rotation: 0,
+        scaleX: 1.0,
+        scaleY: 1.0,
+        positionX: 0,
+        positionY: 0,
+        fadeIn: 0.5,
+        fadeOut: 0.5,
+        volume: 1.0,
+        eqLow: 0,
+        eqMid: 0,
+        eqHigh: 0,
+        denoiseAmount: 0,
+        highpassFreq: 0,
+        echoDelay: 0,
+        echoDecay: 0.3,
+        reverbAmount: 0,
+      },
+      transition: {
+        type: 'crossfade',
+        duration: 0.5,
+      },
+    };
+
+    expect(clipWithEffects.effects?.brightness).toBe(1.2);
+    expect(clipWithEffects.transition?.type).toBe('crossfade');
+  });
+
+  it('createdAt / updatedAt が ISO 8601 形式の文字列である', () => {
+    expect(() => new Date(validProject.createdAt).toISOString()).not.toThrow();
+    expect(() => new Date(validProject.updatedAt).toISOString()).not.toThrow();
+  });
+
+  it('metadata.basePath はオプショナルである', () => {
+    expect(validProject.metadata.basePath).toBeUndefined();
+
+    const withBasePath: ProjectFile = {
+      ...validProject,
+      metadata: { name: 'test', basePath: '/Users/test/videos' },
+    };
+    expect(withBasePath.metadata.basePath).toBe('/Users/test/videos');
+  });
+});

--- a/src/types/projectFile.ts
+++ b/src/types/projectFile.ts
@@ -1,0 +1,69 @@
+import type {
+  ClipEffects,
+  TextProperties,
+  ClipTransition,
+} from '../store/timelineStore';
+import type { ExportSettings } from '../store/exportStore';
+
+/**
+ * .qcut プロジェクトファイルの現在のスキーマバージョン
+ *
+ * バージョニング方針:
+ * - フィールド追加（後方互換）: マイナーバージョンを上げる (1 → 2)
+ * - 破壊的変更（既存フィールドの型変更・削除）: メジャーバージョンを上げる (1 → 100)
+ * - 読み込み時はマイグレーション関数で古いバージョンを最新に変換する
+ */
+export const CURRENT_SCHEMA_VERSION = 1;
+
+// --- プロジェクトファイルのルート ---
+
+export interface ProjectFile {
+  schemaVersion: number;
+  appVersion: string;
+  createdAt: string;  // ISO 8601
+  updatedAt: string;  // ISO 8601
+  metadata: ProjectMetadata;
+  timeline: ProjectTimeline;
+  exportSettings: ExportSettings;
+}
+
+// --- メタデータ ---
+
+export interface ProjectMetadata {
+  name: string;
+  /** プロジェクトファイルの保存先ディレクトリからの相対パスで素材を参照するための基準パス */
+  basePath?: string;
+}
+
+// --- タイムライン ---
+
+export interface ProjectTimeline {
+  tracks: ProjectTrack[];
+}
+
+export interface ProjectTrack {
+  id: string;
+  type: 'video' | 'audio' | 'text';
+  name: string;
+  clips: ProjectClip[];
+  volume: number;
+  mute: boolean;
+  solo: boolean;
+}
+
+export interface ProjectClip {
+  id: string;
+  name: string;
+  startTime: number;
+  duration: number;
+  color?: string;
+
+  /** 素材ファイルパス（プロジェクトファイルからの相対パス） */
+  filePath: string;
+  sourceStartTime: number;
+  sourceEndTime: number;
+
+  effects?: ClipEffects;
+  textProperties?: TextProperties;
+  transition?: ClipTransition;
+}


### PR DESCRIPTION
Closes #102

## Summary
- `.qcut` プロジェクトファイルの JSON スキーマを TypeScript 型定義として設計
- `ProjectFile`, `ProjectMetadata`, `ProjectTimeline`, `ProjectTrack`, `ProjectClip` インターフェースを定義
- スキーマバージョニング(`CURRENT_SCHEMA_VERSION = 1`)を導入

## 設計方針
- **フォーマット**: JSON ベース（可読性・デバッグ性重視）
- **ファイルパス**: 素材ファイルはプロジェクトファイルからの相対パスで保持
- **バージョニング**: フィールド追加はマイナー、破壊的変更はメジャーで管理。読み込み時にマイグレーション関数で変換
- **既存型の再利用**: `ClipEffects`, `TextProperties`, `ClipTransition`, `ExportSettings` は既存の定義をそのまま利用

## ファイル構成
- `src/types/projectFile.ts` — 型定義・定数
- `src/test/projectFile.test.ts` — スキーマ適合テスト（7テスト）

## 手動テスト手順
- [ ] `npm run lint` がエラーなしで通ること
- [ ] `npm run test` で全テスト（146件）がパスすること
- [ ] `npm run build` が成功すること