### PR TITLE
最近開いたプロジェクト一覧を実装

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -80,6 +80,33 @@ pub fn read_project(path: String) -> Result<String, String> {
     .map_err(|e| format!("ファイルの読み込みに失敗: {}", e))
 }
 
+/// 最近のプロジェクト一覧を読み込む
+#[tauri::command]
+pub fn read_recent_projects(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let app_data = app_handle.path().app_data_dir()
+        .map_err(|e| format!("app_data_dir の取得に失敗: {}", e))?;
+    let path = app_data.join("recent_projects.json");
+    if !path.exists() {
+        return Ok("[]".to_string());
+    }
+    fs::read_to_string(&path)
+        .map_err(|e| format!("ファイルの読み込みに失敗: {}", e))
+}
+
+/// 最近のプロジェクト一覧を書き込む
+#[tauri::command]
+pub fn write_recent_projects(app_handle: tauri::AppHandle, content: String) -> Result<(), String> {
+    let app_data = app_handle.path().app_data_dir()
+        .map_err(|e| format!("app_data_dir の取得に失敗: {}", e))?;
+    let path = app_data.join("recent_projects.json");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("ディレクトリの作成に失敗: {}", e))?;
+    }
+    fs::write(&path, content)
+        .map_err(|e| format!("ファイルの書き込みに失敗: {}", e))
+}
+
 /// UUIDベースの自動保存ファイルパスを生成する
 #[tauri::command]
 pub fn get_autosave_path(app_handle: tauri::AppHandle) -> Result<String, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,8 @@ pub fn run() {
       commands::files::get_autosave_path,
       commands::files::delete_file,
       commands::files::list_autosaves,
+      commands::files::read_recent_projects,
+      commands::files::write_recent_projects,
       commands::plugins::list_plugin_dirs,
       commands::plugins::read_plugin_manifest,
       commands::plugins::read_plugin_file,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ function App() {
     const projectStore = useProjectStore.getState();
     projectStore.checkAndRecoverAutosave();
     projectStore.startAutosave();
+    projectStore.loadRecentProjects();
     return () => {
       projectStore.stopAutosave();
     };

--- a/src/components/FileOperations/FileOperations.tsx
+++ b/src/components/FileOperations/FileOperations.tsx
@@ -20,7 +20,10 @@ export const FileOperations: React.FC = () => {
 
   const { registerVideoUrl } = useVideoPreviewStore();
   const { addClip, addTrack, tracks } = useTimelineStore();
-  const { saveProject, saveProjectAs, saveStatus, openProject, loadStatus } = useProjectStore();
+  const {
+    saveProject, saveProjectAs, saveStatus, openProject, loadStatus,
+    recentProjects, loadProjectFromPath, clearRecentProjects, removeRecentProject, isDirty,
+  } = useProjectStore();
 
   const [showMenu, setShowMenu] = useState(false);
 
@@ -198,6 +201,19 @@ export const FileOperations: React.FC = () => {
     }
   };
 
+  const handleOpenRecentProject = async (path: string) => {
+    if (isDirty) {
+      const { ask } = await import('@tauri-apps/plugin-dialog');
+      const proceed = await ask(
+        '未保存の変更があります。保存せずに別のプロジェクトを開きますか？',
+        { title: 'qcut', kind: 'warning' },
+      );
+      if (!proceed) return;
+    }
+    setShowMenu(false);
+    await loadProjectFromPath(path);
+  };
+
 
   return (
     <div style={{ position: 'relative' }}>
@@ -346,6 +362,120 @@ export const FileOperations: React.FC = () => {
           >
             📂 {t('menu.open')}
           </button>
+
+          {/* 区切り線 - 最近のプロジェクト */}
+          {recentProjects.length > 0 && (
+            <div
+              style={{
+                height: '1px',
+                backgroundColor: '#3a3a3a',
+                margin: '4px 0',
+              }}
+            />
+          )}
+
+          {/* 最近のプロジェクト */}
+          {recentProjects.length > 0 && (
+            <div>
+              <div
+                style={{
+                  padding: '8px 16px',
+                  fontSize: '12px',
+                  color: '#999',
+                  fontWeight: 'bold',
+                }}
+              >
+                {t('menu.recentProjects')}
+              </div>
+              {recentProjects.map((project) => (
+                <button
+                  key={project.path}
+                  onClick={() => {
+                    if (project.exists) {
+                      handleOpenRecentProject(project.path);
+                    }
+                  }}
+                  disabled={!project.exists}
+                  title={project.path}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    width: '100%',
+                    padding: '8px 16px',
+                    textAlign: 'left',
+                    backgroundColor: 'transparent',
+                    color: project.exists ? '#bbb' : '#666',
+                    border: 'none',
+                    cursor: project.exists ? 'pointer' : 'not-allowed',
+                    fontSize: '13px',
+                    opacity: project.exists ? 1 : 0.5,
+                  }}
+                  onMouseEnter={(e) => {
+                    if (project.exists) e.currentTarget.style.backgroundColor = '#3a3a3a';
+                  }}
+                  onMouseLeave={(e) =>
+                    (e.currentTarget.style.backgroundColor = 'transparent')
+                  }
+                >
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {project.name}
+                  </span>
+                  <span
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeRecentProject(project.path);
+                    }}
+                    style={{
+                      marginLeft: '8px',
+                      color: '#666',
+                      cursor: 'pointer',
+                      fontSize: '11px',
+                      flexShrink: 0,
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.color = '#fff')}
+                    onMouseLeave={(e) => (e.currentTarget.style.color = '#666')}
+                  >
+                    ✕
+                  </span>
+                </button>
+              ))}
+
+              <div
+                style={{
+                  height: '1px',
+                  backgroundColor: '#3a3a3a',
+                  margin: '4px 0',
+                }}
+              />
+
+              <button
+                onClick={() => {
+                  clearRecentProjects();
+                  setShowMenu(false);
+                }}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  padding: '8px 16px',
+                  textAlign: 'left',
+                  backgroundColor: 'transparent',
+                  color: '#999',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                }}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.style.backgroundColor = '#3a3a3a')
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.style.backgroundColor = 'transparent')
+                }
+              >
+                🗑️ {t('menu.clearProjects')}
+              </button>
+            </div>
+          )}
 
           {/* 区切り線 */}
           {recentFiles.length > 0 && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,7 +10,9 @@
     "saveAs": "Save As...",
     "openProject": "Open Project...",
     "recent": "Recent Files",
-    "clear": "Clear History"
+    "recentProjects": "Recent Projects",
+    "clear": "Clear History",
+    "clearProjects": "Clear Project History"
   },
   "button": {
     "play": "▶",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -10,7 +10,9 @@
     "saveAs": "名前を付けて保存...",
     "openProject": "プロジェクトを開く...",
     "recent": "最近のファイル",
-    "clear": "履歴をクリア"
+    "recentProjects": "最近のプロジェクト",
+    "clear": "履歴をクリア",
+    "clearProjects": "プロジェクト履歴をクリア"
   },
   "button": {
     "play": "▶",

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -25,6 +25,14 @@ export function _resetAutosaveState(): void {
 }
 
 export const AUTOSAVE_DEBOUNCE_MS = 5 * 1000; // 編集操作後5秒で自動保存
+export const MAX_RECENT_PROJECTS = 10;
+
+export interface RecentProject {
+  name: string;
+  path: string;
+  lastOpened: number;
+  exists?: boolean;
+}
 
 export interface ProjectState {
   projectFilePath: string | null;
@@ -35,6 +43,7 @@ export interface ProjectState {
   loadStatus: LoadStatus;
   loadError: string | null;
   missingFiles: string[];
+  recentProjects: RecentProject[];
 
   setProjectFilePath: (path: string | null) => void;
   setProjectName: (name: string) => void;
@@ -53,6 +62,12 @@ export interface ProjectState {
   performAutosave: () => Promise<void>;
   checkAndRecoverAutosave: () => Promise<void>;
   deleteAutosave: () => Promise<void>;
+
+  // 最近のプロジェクト
+  loadRecentProjects: () => Promise<void>;
+  addRecentProject: (name: string, path: string) => Promise<void>;
+  removeRecentProject: (path: string) => Promise<void>;
+  clearRecentProjects: () => Promise<void>;
 }
 
 function buildProjectFile(projectName: string): ProjectFile {
@@ -197,6 +212,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   loadStatus: 'idle',
   loadError: null,
   missingFiles: [],
+  recentProjects: [],
 
   setProjectFilePath: (path) => set({ projectFilePath: path }),
   setProjectName: (name) => set({ projectName: name }),
@@ -216,6 +232,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       set({ isDirty: false, saveStatus: 'saved', saveError: null });
       // 手動保存成功時に自動保存ファイルを削除
       get().deleteAutosave();
+      get().addRecentProject(projectName, projectFilePath);
       setTimeout(() => {
         if (get().saveStatus === 'saved') {
           set({ saveStatus: 'idle' });
@@ -250,6 +267,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       set({ isDirty: false, saveStatus: 'saved', saveError: null });
       // 手動保存成功時に自動保存ファイルを削除
       get().deleteAutosave();
+      get().addRecentProject(name, filePath);
       setTimeout(() => {
         if (get().saveStatus === 'saved') {
           set({ saveStatus: 'idle' });
@@ -307,6 +325,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         saveStatus: 'idle',
         saveError: null,
       });
+
+      get().addRecentProject(name, path);
 
       if (missing.length > 0) {
         await message(
@@ -451,6 +471,70 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       autosaveFilePath = null;
     } catch (e) {
       console.error('[autosave] 削除に失敗:', e);
+    }
+  },
+
+  // --- 最近のプロジェクト ---
+
+  loadRecentProjects: async () => {
+    try {
+      const json = await invoke<string>('read_recent_projects');
+      const projects: RecentProject[] = JSON.parse(json);
+
+      // 各ファイルの存在確認
+      const checked = await Promise.all(
+        projects.map(async (p) => {
+          try {
+            await invoke('get_file_info', { path: p.path });
+            return { ...p, exists: true };
+          } catch {
+            return { ...p, exists: false };
+          }
+        }),
+      );
+
+      set({ recentProjects: checked });
+    } catch (e) {
+      console.error('[recentProjects] 読み込みに失敗:', e);
+    }
+  },
+
+  addRecentProject: async (name: string, path: string) => {
+    const { recentProjects } = get();
+    const filtered = recentProjects.filter((p) => p.path !== path);
+    const updated: RecentProject[] = [
+      { name, path, lastOpened: Date.now(), exists: true },
+      ...filtered,
+    ].slice(0, MAX_RECENT_PROJECTS);
+
+    set({ recentProjects: updated });
+
+    try {
+      const toSave = updated.map(({ name, path, lastOpened }) => ({ name, path, lastOpened }));
+      await invoke('write_recent_projects', { content: JSON.stringify(toSave) });
+    } catch (e) {
+      console.error('[recentProjects] 書き込みに失敗:', e);
+    }
+  },
+
+  removeRecentProject: async (path: string) => {
+    const updated = get().recentProjects.filter((p) => p.path !== path);
+    set({ recentProjects: updated });
+
+    try {
+      const toSave = updated.map(({ name, path, lastOpened }) => ({ name, path, lastOpened }));
+      await invoke('write_recent_projects', { content: JSON.stringify(toSave) });
+    } catch (e) {
+      console.error('[recentProjects] 書き込みに失敗:', e);
+    }
+  },
+
+  clearRecentProjects: async () => {
+    set({ recentProjects: [] });
+    try {
+      await invoke('write_recent_projects', { content: '[]' });
+    } catch (e) {
+      console.error('[recentProjects] クリアに失敗:', e);
     }
   },
 }));

--- a/src/test/projectStore.test.ts
+++ b/src/test/projectStore.test.ts
@@ -471,4 +471,91 @@ describe('projectStore', () => {
     expect(deleteCall).toBeDefined();
     expect(deleteCall![1]).toEqual({ path: '/tmp/autosave-test-uuid.qcut' });
   });
+
+  // --- 最近のプロジェクト ---
+
+  it('loadRecentProjects でファイルを読み込み存在確認する', async () => {
+    const recentData = [
+      { name: 'Project1', path: '/tmp/project1.qcut', lastOpened: 1000 },
+      { name: 'Project2', path: '/tmp/project2.qcut', lastOpened: 2000 },
+    ];
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'read_recent_projects') return JSON.stringify(recentData);
+      if (cmd === 'get_file_info') {
+        if ((args as { path: string }).path === '/tmp/project2.qcut') throw new Error('not found');
+        return { name: 'project1.qcut', path: '/tmp/project1.qcut', size: 100, last_modified: 0 };
+      }
+      return undefined;
+    });
+
+    await useProjectStore.getState().loadRecentProjects();
+
+    const { recentProjects } = useProjectStore.getState();
+    expect(recentProjects).toHaveLength(2);
+    expect(recentProjects[0].exists).toBe(true);
+    expect(recentProjects[1].exists).toBe(false);
+  });
+
+  it('addRecentProject で先頭に追加され最大10件に制限される', async () => {
+    const existing = Array.from({ length: 10 }, (_, i) => ({
+      name: `Project${i}`,
+      path: `/tmp/project${i}.qcut`,
+      lastOpened: i * 1000,
+      exists: true,
+    }));
+    useProjectStore.setState({ recentProjects: existing });
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    await useProjectStore.getState().addRecentProject('NewProject', '/tmp/new.qcut');
+
+    const { recentProjects } = useProjectStore.getState();
+    expect(recentProjects).toHaveLength(10);
+    expect(recentProjects[0].name).toBe('NewProject');
+    expect(recentProjects[0].path).toBe('/tmp/new.qcut');
+    // 末尾の1件（project9）が削除されている
+    expect(recentProjects.find((p) => p.path === '/tmp/project9.qcut')).toBeUndefined();
+  });
+
+  it('addRecentProject で重複パスは先頭に移動する', async () => {
+    const existing = [
+      { name: 'A', path: '/tmp/a.qcut', lastOpened: 1000, exists: true },
+      { name: 'B', path: '/tmp/b.qcut', lastOpened: 2000, exists: true },
+    ];
+    useProjectStore.setState({ recentProjects: existing });
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    await useProjectStore.getState().addRecentProject('B-updated', '/tmp/b.qcut');
+
+    const { recentProjects } = useProjectStore.getState();
+    expect(recentProjects).toHaveLength(2);
+    expect(recentProjects[0].path).toBe('/tmp/b.qcut');
+    expect(recentProjects[0].name).toBe('B-updated');
+  });
+
+  it('removeRecentProject で指定パスを削除する', async () => {
+    const existing = [
+      { name: 'A', path: '/tmp/a.qcut', lastOpened: 1000, exists: true },
+      { name: 'B', path: '/tmp/b.qcut', lastOpened: 2000, exists: true },
+    ];
+    useProjectStore.setState({ recentProjects: existing });
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    await useProjectStore.getState().removeRecentProject('/tmp/a.qcut');
+
+    const { recentProjects } = useProjectStore.getState();
+    expect(recentProjects).toHaveLength(1);
+    expect(recentProjects[0].path).toBe('/tmp/b.qcut');
+  });
+
+  it('clearRecentProjects で全件削除する', async () => {
+    useProjectStore.setState({
+      recentProjects: [{ name: 'A', path: '/tmp/a.qcut', lastOpened: 1000, exists: true }],
+    });
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    await useProjectStore.getState().clearRecentProjects();
+
+    expect(useProjectStore.getState().recentProjects).toHaveLength(0);
+    expect(invoke).toHaveBeenCalledWith('write_recent_projects', { content: '[]' });
+  });
 });


### PR DESCRIPTION
## Summary
- ファイルメニューに最近開いた/保存したプロジェクトの履歴を表示
- `app_data_dir/recent_projects.json` に永続化（最大10件）
- 存在しないファイルはグレーアウト、個別削除可

Closes #106

## 変更内容
- **Rust**: `read_recent_projects` / `write_recent_projects` コマンド追加
- **projectStore**: `loadRecentProjects`, `addRecentProject`, `removeRecentProject`, `clearRecentProjects` 追加
- **FileOperations**: 最近のプロジェクト一覧をドロップダウンメニューに表示
- **App.tsx**: 起動時に `loadRecentProjects` を呼び出し
- i18n キー追加（ja/en）
- テスト5件追加（全182テストパス）

## 手打鍵
- [x] プロジェクトを保存後、ファイルメニューに最近のプロジェクトとして表示されることを確認
- [x] 最近のプロジェクトからワンクリックでプロジェクトが開けることを確認
- [x] 未保存の変更がある状態で最近のプロジェクトを開こうとすると警告ダイアログが表示されることを確認
- [x] 存在しないファイルがグレーアウトされクリックできないことを確認
- [x] 個別の✕ボタンで履歴から削除できることを確認
- [x] 「プロジェクト履歴をクリア」で全件削除されることを確認
- [x] アプリを再起動しても履歴が保持されていることを確認
- [ ] 11件目のプロジェクトを追加すると最も古い1件が削除されることを確認