### PR TITLE
色温度・色相調整機能を追加

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -17,6 +17,10 @@ pub struct ClipEffects {
     pub brightness: f64,
     pub contrast: f64,
     pub saturation: f64,
+    #[serde(default)]
+    pub color_temperature: f64,
+    #[serde(default)]
+    pub hue: f64,
     pub rotation: f64,
     pub scale_x: f64,
     pub scale_y: f64,

--- a/src-tauri/src/commands/ffmpeg_builder.rs
+++ b/src-tauri/src/commands/ffmpeg_builder.rs
@@ -249,6 +249,31 @@ pub(crate) fn build_ffmpeg_args(
                 ));
             }
 
+            // 色相シフト
+            if effects.hue.abs() > 0.1 {
+                vfilter.push_str(&format!(",hue=h={:.1}", effects.hue));
+            }
+
+            // 色温度（colorbalance フィルタで近似）
+            if effects.color_temperature.abs() > 0.01 {
+                let t = effects.color_temperature;
+                if t > 0.0 {
+                    let rs = t * 0.3;
+                    let bs = -t * 0.3;
+                    vfilter.push_str(&format!(
+                        ",colorbalance=rs={:.2}:bs={:.2}:rm={:.2}:bm={:.2}",
+                        rs, bs, rs * 0.5, bs * 0.5
+                    ));
+                } else {
+                    let bs = -t * 0.3;
+                    let rs = t * 0.3;
+                    vfilter.push_str(&format!(
+                        ",colorbalance=rs={:.2}:bs={:.2}:rm={:.2}:bm={:.2}",
+                        rs, bs, rs * 0.5, bs * 0.5
+                    ));
+                }
+            }
+
             // スケール
             if (effects.scale_x - 1.0).abs() > 0.01 || (effects.scale_y - 1.0).abs() > 0.01 {
                 vfilter.push_str(&format!(

--- a/src/components/Inspector/EffectsPanel.tsx
+++ b/src/components/Inspector/EffectsPanel.tsx
@@ -129,6 +129,22 @@ export const EffectsPanel: React.FC = () => {
             value={effects.saturation}
             onChange={(v) => handleChange('saturation', v)}
           />
+          <EffectSlider
+            label={t('effects.colorTemperature')}
+            value={effects.colorTemperature}
+            onChange={(v) => handleChange('colorTemperature', v)}
+            min={-1}
+            max={1}
+            step={0.01}
+          />
+          <EffectSlider
+            label={t('effects.hue')}
+            value={effects.hue}
+            onChange={(v) => handleChange('hue', v)}
+            min={-180}
+            max={180}
+            step={1}
+          />
 
           <h4 style={{ margin: '16px 0 8px 0', fontSize: '13px', color: '#ddd', borderTop: '1px solid #3a3a3a', paddingTop: '12px' }}>
             {t('transform.title')}

--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -182,7 +182,25 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
   const cssFilter = useMemo(() => {
     if (!currentClip?.effects) return 'none';
     const e = currentClip.effects;
-    return `brightness(${e.brightness}) contrast(${e.contrast}) saturate(${e.saturation})`;
+    let filter = `brightness(${e.brightness}) contrast(${e.contrast}) saturate(${e.saturation})`;
+
+    const hue = e.hue ?? 0;
+    if (hue !== 0) {
+      filter += ` hue-rotate(${hue}deg)`;
+    }
+
+    const temp = e.colorTemperature ?? 0;
+    if (temp > 0.01) {
+      const sepiaAmount = temp * 0.3;
+      const hueShift = temp * -10;
+      filter += ` sepia(${sepiaAmount}) hue-rotate(${hueShift}deg)`;
+    } else if (temp < -0.01) {
+      const hueShift = temp * 30;
+      const satBoost = 1 + Math.abs(temp) * 0.2;
+      filter += ` hue-rotate(${hueShift}deg) saturate(${satBoost})`;
+    }
+
+    return filter;
   }, [currentClip?.effects]);
 
   const cssTransform = useMemo(() => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -43,6 +43,8 @@
     "brightness": "Brightness",
     "contrast": "Contrast",
     "saturation": "Saturation",
+    "colorTemperature": "Color Temperature",
+    "hue": "Hue",
     "reset": "Reset",
     "audio": "Audio",
     "volume": "Volume",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -43,6 +43,8 @@
     "brightness": "明るさ",
     "contrast": "コントラスト",
     "saturation": "彩度",
+    "colorTemperature": "色温度",
+    "hue": "色相",
     "reset": "リセット",
     "audio": "オーディオ",
     "volume": "音量",

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -5,6 +5,8 @@ export interface ClipEffects {
   brightness: number;  // 0〜2, default 1.0
   contrast: number;    // 0〜2, default 1.0
   saturation: number;  // 0〜2, default 1.0
+  colorTemperature: number;  // -1〜1, default 0 (negative=cool, positive=warm)
+  hue: number;               // -180〜180, default 0
   rotation: number;    // -180〜180, default 0
   scaleX: number;      // 0.1〜3, default 1.0
   scaleY: number;      // 0.1〜3, default 1.0
@@ -27,6 +29,8 @@ export const DEFAULT_EFFECTS: ClipEffects = {
   brightness: 1.0,
   contrast: 1.0,
   saturation: 1.0,
+  colorTemperature: 0,
+  hue: 0,
   rotation: 0,
   scaleX: 1.0,
   scaleY: 1.0,

--- a/src/test/colorTempHueEffect.test.ts
+++ b/src/test/colorTempHueEffect.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTimelineStore, DEFAULT_EFFECTS } from '../store/timelineStore';
+
+describe('color temperature and hue effects', () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [],
+      selectedClipId: null,
+      selectedTrackId: null,
+      currentTime: 0,
+      isPlaying: false,
+      pixelsPerSecond: 50,
+    });
+  });
+
+  it('should have colorTemperature and hue in DEFAULT_EFFECTS with default value 0', () => {
+    expect(DEFAULT_EFFECTS.colorTemperature).toBe(0);
+    expect(DEFAULT_EFFECTS.hue).toBe(0);
+  });
+
+  it('should store colorTemperature in clip effects', () => {
+    const { addTrack, addClip, updateClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+
+    updateClip('video-1', 'clip-1', {
+      effects: { ...DEFAULT_EFFECTS, colorTemperature: 0.5 },
+    });
+
+    const state = useTimelineStore.getState();
+    const clip = state.tracks[0].clips[0];
+    expect(clip.effects?.colorTemperature).toBe(0.5);
+  });
+
+  it('should store hue in clip effects', () => {
+    const { addTrack, addClip, updateClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+
+    updateClip('video-1', 'clip-1', {
+      effects: { ...DEFAULT_EFFECTS, hue: 90 },
+    });
+
+    const state = useTimelineStore.getState();
+    const clip = state.tracks[0].clips[0];
+    expect(clip.effects?.hue).toBe(90);
+  });
+
+  it('should reset colorTemperature and hue to defaults', () => {
+    const { addTrack, addClip, updateClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+
+    updateClip('video-1', 'clip-1', {
+      effects: { ...DEFAULT_EFFECTS, colorTemperature: -0.8, hue: -120 },
+    });
+
+    updateClip('video-1', 'clip-1', {
+      effects: { ...DEFAULT_EFFECTS },
+    });
+
+    const state = useTimelineStore.getState();
+    const clip = state.tracks[0].clips[0];
+    expect(clip.effects?.colorTemperature).toBe(0);
+    expect(clip.effects?.hue).toBe(0);
+  });
+
+  it('should include colorTemperature and hue in JSON serialization', () => {
+    const { addTrack, addClip, updateClip } = useTimelineStore.getState();
+    addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
+    addClip('video-1', {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
+
+    updateClip('video-1', 'clip-1', {
+      effects: { ...DEFAULT_EFFECTS, colorTemperature: 0.7, hue: 45 },
+    });
+
+    const state = useTimelineStore.getState();
+    const clip = state.tracks[0].clips[0];
+    const json = JSON.stringify(clip);
+    const parsed = JSON.parse(json);
+    expect(parsed.effects.colorTemperature).toBe(0.7);
+    expect(parsed.effects.hue).toBe(45);
+  });
+});


### PR DESCRIPTION
## Summary
- クリップに色温度（-1〜1）と色相（-180°〜180°）の調整エフェクトを追加
- EffectsPanelにスライダーUI、VideoPreviewにCSSフィルタープレビュー、エクスポート時のFFmpegフィルター生成を実装

Closes #116

## 変更内容
- `ClipEffects` に `colorTemperature`, `hue` フィールド追加
- EffectsPanel に2つのスライダー追加（彩度の下、トランスフォームセクションの上）
- VideoPreview の `cssFilter` を拡張（hue-rotate、sepia/hue-rotateによる色温度近似）
- Rust側: `ClipEffects` 構造体にフィールド追加（`#[serde(default)]` で後方互換）
- FFmpegフィルター: `hue=h=` で色相シフト、`colorbalance` で色温度を近似
- i18nラベル追加（ja: 色温度/色相、en: Color Temperature/Hue）
- ユニットテスト5件追加

## 手打鍵
- [x] クリップを選択し、エフェクトパネルに「色温度」「色相」スライダーが表示されること
- [x] 色温度スライダーを暖色方向（+）に動かすとプレビューがオレンジ寄りになること
- [x] 色温度スライダーを寒色方向（-）に動かすとプレビューが青寄りになること
- [x] 色相スライダーを動かすとプレビューの色味が回転すること
- [x] リセットボタンで両方が0に戻ること
- [x] エクスポートした動画にエフェクトが反映されていること
- [x] 既存プロジェクトファイル（colorTemperature/hueなし）が問題なく開けること