### PR TITLE
クリップ削除ボタンが動作しない問題を修正

### DIFF
--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -46,9 +46,15 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
   const hasTransition = !!clip.transition;
 
   const handleMouseDown = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
     if (e.button === 0) {
+      // 削除ボタンはドラッグ対象外
+      if (target.classList.contains('clip-delete')) {
+        setSelectedClip(trackId, clip.id);
+        return;
+      }
       // 左クリックのみドラッグ/リサイズを開始
-      if ((e.target as HTMLElement).classList.contains('clip-resize-handle')) {
+      if (target.classList.contains('clip-resize-handle')) {
         setIsResizing(true);
       } else {
         setIsDragging(true);


### PR DESCRIPTION
## Summary
- handleMouseDownが削除ボタンのクリックでもドラッグモードを開始してしまい、onClickが正常に発火しなかった
- handleMouseDownでe.targetがclip-deleteクラスの場合は早期リターンするよう修正

## Test plan
- [ ] クリップの×ボタンをクリックしてクリップが削除されることを確認
- [ ] クリップのドラッグ移動が引き続き正常に動作することを確認
- [ ] クリップのリサイズが引き続き正常に動作することを確認