### PR TITLE
JSON設定ファイルによるカスタムエクスポートフォーマット定義（Issue #170）

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 
-use super::ffmpeg_builder::{build_ffmpeg_args, collect_audio_clips, collect_text_clips, collect_video_clips, list_format_infos, FormatInfo};
+use super::ffmpeg_builder::{build_ffmpeg_args, collect_audio_clips, collect_text_clips, collect_video_clips, list_format_infos, CustomFormatEntry, FormatInfo};
 use super::progress_parser::ProgressParser;
 
 // --- データ構造 ---
@@ -220,6 +220,10 @@ pub struct ExportState {
     pub cancel_flag: Arc<AtomicBool>,
 }
 
+pub struct CustomFormatsState {
+    pub formats: std::sync::Mutex<Vec<CustomFormatEntry>>,
+}
+
 // --- コマンド ---
 
 #[tauri::command]
@@ -245,6 +249,7 @@ pub async fn export_video(
     app_handle: AppHandle,
     settings: ExportSettings,
     state: tauri::State<'_, ExportState>,
+    custom_formats_state: tauri::State<'_, CustomFormatsState>,
 ) -> Result<(), String> {
     // キャンセルフラグをリセット
     state.cancel_flag.store(false, Ordering::SeqCst);
@@ -278,7 +283,9 @@ pub async fn export_video(
     }
 
     // FFmpegコマンドを構築
-    let build_result = build_ffmpeg_args(&settings, &video_clips, &text_clips, &audio_track_clips)?;
+    let custom_formats = custom_formats_state.formats.lock().unwrap();
+    let build_result = build_ffmpeg_args(&settings, &video_clips, &text_clips, &audio_track_clips, &custom_formats)?;
+    drop(custom_formats);
     let args = build_result.args;
     let temp_files = build_result.temp_files;
     log::info!("FFmpeg command: {} {}", super::ffmpeg_path::ffmpeg_path(), args.join(" "));
@@ -388,6 +395,7 @@ pub fn cancel_export(state: tauri::State<'_, ExportState>) -> Result<(), String>
 }
 
 #[tauri::command]
-pub fn get_export_formats() -> Vec<FormatInfo> {
-    list_format_infos()
+pub fn get_export_formats(state: tauri::State<'_, CustomFormatsState>) -> Vec<FormatInfo> {
+    let custom = state.formats.lock().unwrap();
+    list_format_infos(&custom)
 }

--- a/src-tauri/src/commands/ffmpeg_builder.rs
+++ b/src-tauri/src/commands/ffmpeg_builder.rs
@@ -93,6 +93,101 @@ const FORMAT_PROFILES: &[FormatProfile] = &[
     },
 ];
 
+// --- コーデック許可リスト（コマンドインジェクション対策）---
+
+const ALLOWED_VIDEO_CODECS: &[&str] = &[
+    "libx264", "libx265", "libvpx-vp9", "libaom-av1",
+];
+
+const ALLOWED_AUDIO_CODECS: &[&str] = &[
+    "aac", "mp3", "libopus", "flac", "pcm_s16le", "libvorbis",
+];
+
+// --- カスタムフォーマット ---
+
+/// JSON 設定ファイルから読み込むカスタムフォーマットエントリ
+#[derive(Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CustomFormatEntry {
+    pub key: String,
+    pub label: String,
+    pub ext: String,
+    pub filter_name: String,
+    pub video_codec: String,
+    pub audio_codec: String,
+    pub audio_bitrate: String,
+    #[serde(default)]
+    pub video_preset: Option<String>,
+    #[serde(default)]
+    pub container: Option<String>,
+}
+
+/// カスタムフォーマットのバリデーション（許可リスト方式）
+pub(crate) fn validate_custom_format(entry: &CustomFormatEntry) -> Result<(), String> {
+    if !ALLOWED_VIDEO_CODECS.contains(&entry.video_codec.as_str()) {
+        return Err(format!("不正な videoCodec: {} (許可リスト外)", entry.video_codec));
+    }
+    if !ALLOWED_AUDIO_CODECS.contains(&entry.audio_codec.as_str()) {
+        return Err(format!("不正な audioCodec: {} (許可リスト外)", entry.audio_codec));
+    }
+    let re = Regex::new(r"^\d+k$").unwrap();
+    if !re.is_match(&entry.audio_bitrate) {
+        return Err(format!("不正な audioBitrate: {} (例: 128k)", entry.audio_bitrate));
+    }
+    Ok(())
+}
+
+// --- フォーマット解決 ---
+
+/// build_ffmpeg_args で使う所有権付きフォーマットプロファイル
+pub(crate) struct OwnedFormatProfile {
+    pub video_codec: String,
+    pub video_preset: Option<String>,
+    pub audio_codec: String,
+    pub audio_bitrate: String,
+    pub container: Option<String>,
+    pub extra_flags: Vec<String>,
+}
+
+/// フォーマットキーから OwnedFormatProfile を解決する。
+/// 静的プロファイルを優先し、見つからなければカスタムフォーマット、
+/// それも見つからなければ mp4 にフォールバック。
+pub(crate) fn resolve_format_profile(
+    key: &str,
+    custom: &[CustomFormatEntry],
+) -> OwnedFormatProfile {
+    if let Some(p) = FORMAT_PROFILES.iter().find(|p| p.key == key) {
+        return OwnedFormatProfile {
+            video_codec: p.video_codec.to_string(),
+            video_preset: p.video_preset.map(|s| s.to_string()),
+            audio_codec: p.audio_codec.to_string(),
+            audio_bitrate: p.audio_bitrate.to_string(),
+            container: p.container.map(|s| s.to_string()),
+            extra_flags: p.extra_flags.iter().map(|s| s.to_string()).collect(),
+        };
+    }
+    if let Some(f) = custom.iter().find(|f| f.key == key) {
+        return OwnedFormatProfile {
+            video_codec: f.video_codec.clone(),
+            video_preset: f.video_preset.clone(),
+            audio_codec: f.audio_codec.clone(),
+            audio_bitrate: f.audio_bitrate.clone(),
+            container: f.container.clone(),
+            extra_flags: vec![],
+        };
+    }
+    // デフォルト: mp4
+    let p = &FORMAT_PROFILES[0];
+    OwnedFormatProfile {
+        video_codec: p.video_codec.to_string(),
+        video_preset: p.video_preset.map(|s| s.to_string()),
+        audio_codec: p.audio_codec.to_string(),
+        audio_bitrate: p.audio_bitrate.to_string(),
+        container: p.container.map(|s| s.to_string()),
+        extra_flags: p.extra_flags.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
 /// フロントエンドへ返すフォーマット情報
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -103,9 +198,9 @@ pub(crate) struct FormatInfo {
     pub filter_name: String,
 }
 
-/// 利用可能なエクスポートフォーマット一覧を返す
-pub(crate) fn list_format_infos() -> Vec<FormatInfo> {
-    FORMAT_PROFILES
+/// 利用可能なエクスポートフォーマット一覧を返す（組み込み + カスタム）
+pub(crate) fn list_format_infos(custom: &[CustomFormatEntry]) -> Vec<FormatInfo> {
+    let mut infos: Vec<FormatInfo> = FORMAT_PROFILES
         .iter()
         .map(|p| FormatInfo {
             key: p.key.to_string(),
@@ -113,14 +208,16 @@ pub(crate) fn list_format_infos() -> Vec<FormatInfo> {
             ext: p.ext.to_string(),
             filter_name: p.filter_name.to_string(),
         })
-        .collect()
-}
-
-pub(crate) fn get_format_profile(key: &str) -> &'static FormatProfile {
-    FORMAT_PROFILES
-        .iter()
-        .find(|p| p.key == key)
-        .unwrap_or(&FORMAT_PROFILES[0]) // mp4 をデフォルトにフォールバック
+        .collect();
+    for f in custom {
+        infos.push(FormatInfo {
+            key: f.key.clone(),
+            label: f.label.clone(),
+            ext: f.ext.clone(),
+            filter_name: f.filter_name.clone(),
+        });
+    }
+    infos
 }
 
 // --- ヘルパー関数 ---
@@ -226,6 +323,7 @@ pub(crate) fn build_ffmpeg_args(
     video_clips: &[VideoTrackClip],
     text_clips: &[&ExportClip],
     audio_track_clips: &[AudioTrackClip],
+    custom_formats: &[CustomFormatEntry],
 ) -> Result<FfmpegBuildResult, String> {
     // セキュリティ: 数値パラメータのバリデーション
     validate_export_settings(settings)?;
@@ -853,11 +951,11 @@ pub(crate) fn build_ffmpeg_args(
     args.push(format!("[{}]", final_a_label));
 
     // フォーマットプロファイルから出力設定を生成
-    let profile = get_format_profile(&settings.format);
+    let profile = resolve_format_profile(&settings.format, custom_formats);
 
-    args.extend(["-c:v".into(), profile.video_codec.into()]);
+    args.extend(["-c:v".into(), profile.video_codec]);
     if let Some(preset) = profile.video_preset {
-        args.extend(["-preset".into(), preset.into()]);
+        args.extend(["-preset".into(), preset]);
     }
     args.extend([
         "-b:v".into(),
@@ -865,15 +963,15 @@ pub(crate) fn build_ffmpeg_args(
         "-r".into(),
         settings.fps.to_string(),
         "-c:a".into(),
-        profile.audio_codec.into(),
+        profile.audio_codec,
         "-b:a".into(),
-        profile.audio_bitrate.into(),
+        profile.audio_bitrate,
     ]);
     if let Some(container) = profile.container {
-        args.extend(["-f".into(), container.into()]);
+        args.extend(["-f".into(), container]);
     }
     for flag in profile.extra_flags {
-        args.push((*flag).into());
+        args.push(flag);
     }
     args.push(settings.output_path.clone());
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,9 @@ pub fn run() {
     .manage(commands::export::ExportState {
       cancel_flag: Arc::new(AtomicBool::new(false)),
     })
+    .manage(commands::export::CustomFormatsState {
+      formats: std::sync::Mutex::new(Vec::new()),
+    })
     .manage(commands::waveform::WaveformCache {
       cache: std::sync::Mutex::new(HashMap::new()),
       in_progress: std::sync::Mutex::new(HashMap::new()),
@@ -32,6 +35,33 @@ pub fn run() {
       if let Err(e) = std::fs::create_dir_all(&app_data_dir) {
         eprintln!("Failed to create app_data_dir {:?}: {}", app_data_dir, e);
       }
+
+      // カスタムエクスポートフォーマットを起動時に読み込む
+      let formats_path = app_data_dir.join("export-formats.json");
+      if formats_path.exists() {
+        match std::fs::read_to_string(&formats_path) {
+          Ok(json) => {
+            match serde_json::from_str::<Vec<commands::ffmpeg_builder::CustomFormatEntry>>(&json) {
+              Ok(entries) => {
+                let valid: Vec<commands::ffmpeg_builder::CustomFormatEntry> = entries.into_iter().filter(|e| {
+                  match commands::ffmpeg_builder::validate_custom_format(e) {
+                    Ok(()) => true,
+                    Err(err) => {
+                      eprintln!("カスタムフォーマット '{}' は無効: {}", e.key, err);
+                      false
+                    }
+                  }
+                }).collect();
+                let state = app.state::<commands::export::CustomFormatsState>();
+                *state.formats.lock().unwrap() = valid;
+              }
+              Err(e) => eprintln!("export-formats.json のパースに失敗: {}", e),
+            }
+          }
+          Err(e) => eprintln!("export-formats.json の読み込みに失敗: {}", e),
+        }
+      }
+
       let db_path = app_data_dir.join("logs.db");
 
       if let Ok(sqlite_logger) = sqlite_logger::SqliteLogger::new(&db_path) {


### PR DESCRIPTION
## Summary

- `{app_data}/export-formats.json` を起動時に読み込み、カスタムエクスポートフォーマットを追加できる仕組みを実装
- コーデック許可リスト（allowlist）によるバリデーションでコマンドインジェクションを防止
- 組み込みフォーマット（mp4/mov/avi/webm）はそのまま維持し、カスタムフォーマットは末尾に追加される

Closes #170

## Test plan

- [ ] `~/Library/Application Support/moe.qcut.app/export-formats.json` にカスタムフォーマットを定義してアプリを起動
  ```json
  [
    {
      "key": "hevc",
      "label": "MP4 (H.265/HEVC)",
      "ext": "mp4",
      "filterName": "MP4",
      "videoCodec": "libx265",
      "audioCodec": "aac",
      "audioBitrate": "128k"
    }
  ]
  ```
- [ ] エクスポートダイアログを開いてカスタムフォーマットが選択肢に表示されることを確認
- [ ] 無効なコーデック（例: `"videoCodec": "rm -rf /"`）を指定した場合に起動ログに警告が出てスキップされることを確認
- [ ] カスタムフォーマットを選択してエクスポートが正常に完了することを確認
- [ ] `export-formats.json` が存在しない場合に組み込みフォーマット（mp4/mov/avi/webm）のみ表示されることを確認