### PR TITLE
プレビュー HLS ストア・フックを実装（Issue #181）

### DIFF
--- a/src/hooks/useHlsPreview.ts
+++ b/src/hooks/useHlsPreview.ts
@@ -17,14 +17,29 @@ interface HlsResult {
   segments: Array<{ hls_start: number; timeline_start: number; duration: number }>;
 }
 
+/** ビデオクリップの軽量シグネチャ（変更検知用） */
+function videoClipSignature(state: ReturnType<typeof useTimelineStore.getState>): string {
+  return state.tracks
+    .filter((tr) => tr.type === 'video')
+    .flatMap((tr) =>
+      tr.clips.map(
+        (c) => `${c.id}:${c.filePath}:${c.startTime}:${c.duration}:${c.sourceStartTime}:${c.sourceEndTime}`,
+      ),
+    )
+    .join('|');
+}
+
 export function useHlsPreview() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const generationIdRef = useRef(0);
 
   useEffect(() => {
     const scheduleGeneration = () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
       debounceRef.current = setTimeout(async () => {
+        const myId = ++generationIdRef.current;
+
         const tracks = useTimelineStore.getState().tracks;
         const clips: HlsClipInput[] = [];
 
@@ -42,13 +57,14 @@ export function useHlsPreview() {
         }
 
         if (clips.length === 0) {
-          useHlsPreviewStore.getState().reset();
+          if (myId === generationIdRef.current) useHlsPreviewStore.getState().reset();
           return;
         }
 
-        useHlsPreviewStore.getState().setIsGenerating(true);
+        if (myId === generationIdRef.current) useHlsPreviewStore.getState().setIsGenerating(true);
         try {
           const result = await invoke<HlsResult>('generate_preview_hls', { clips });
+          if (myId !== generationIdRef.current) return; // 古い結果は破棄
           const segments: HlsSegment[] = result.segments.map((s) => ({
             hlsStart: s.hls_start,
             timelineStart: s.timeline_start,
@@ -56,15 +72,18 @@ export function useHlsPreview() {
           }));
           useHlsPreviewStore.getState().setHlsReady(result.playlist_path, segments);
         } catch (e) {
+          if (myId !== generationIdRef.current) return; // 古いエラーは破棄
           useHlsPreviewStore.getState().setError(String(e));
         }
       }, DEBOUNCE_MS);
     };
 
-    // ビデオトラックのクリップ変化を購読
-    const unsubscribe = useTimelineStore.subscribe((state, prev) => {
-      const videoTracks = (t: typeof state) => t.tracks.filter((tr) => tr.type === 'video');
-      if (JSON.stringify(videoTracks(state)) !== JSON.stringify(videoTracks(prev))) {
+    // ビデオトラックのクリップ変化を購読（軽量シグネチャで比較）
+    let prevSignature = videoClipSignature(useTimelineStore.getState());
+    const unsubscribe = useTimelineStore.subscribe((state) => {
+      const sig = videoClipSignature(state);
+      if (sig !== prevSignature) {
+        prevSignature = sig;
         scheduleGeneration();
       }
     });

--- a/src/store/hlsPreviewStore.ts
+++ b/src/store/hlsPreviewStore.ts
@@ -18,14 +18,18 @@ export function hlsToTimeline(hlsTime: number, segments: HlsSegment[]): number {
   return 0;
 }
 
-/** タイムライン時刻 → HLS 時刻 */
-export function timelineToHls(timelineTime: number, segments: HlsSegment[]): number {
+/** タイムライン時刻 → HLS 時刻。gap 区間または segments が空の場合は null を返す */
+export function timelineToHls(timelineTime: number, segments: HlsSegment[]): number | null {
   for (const seg of segments) {
     if (timelineTime >= seg.timelineStart && timelineTime < seg.timelineStart + seg.duration) {
       return seg.hlsStart + (timelineTime - seg.timelineStart);
     }
   }
-  return 0;
+  const last = segments[segments.length - 1];
+  if (last && timelineTime >= last.timelineStart + last.duration) {
+    return last.hlsStart + last.duration;
+  }
+  return null;
 }
 
 interface HlsPreviewState {
@@ -49,6 +53,6 @@ export const useHlsPreviewStore = create<HlsPreviewState>((set) => ({
   setHlsReady: (path, segments) =>
     set({ hlsPath: path, hlsSegments: segments, error: null, isGenerating: false }),
   setIsGenerating: (generating) => set({ isGenerating: generating }),
-  setError: (error) => set({ error, isGenerating: false }),
+  setError: (error) => set({ error, isGenerating: false, hlsPath: null, hlsSegments: [] }),
   reset: () => set({ hlsPath: null, hlsSegments: [], isGenerating: false, error: null }),
 }));

--- a/src/test/hlsPreviewStore.test.ts
+++ b/src/test/hlsPreviewStore.test.ts
@@ -45,7 +45,12 @@ describe('timelineToHls', () => {
     expect(timelineToHls(8, segments)).toBe(6);
   });
 
-  it('gap 区間（タイムライン 6）は 0 を返す', () => {
-    expect(timelineToHls(6, segments)).toBe(0);
+  it('gap 区間（タイムライン 6）は null を返す', () => {
+    expect(timelineToHls(6, segments)).toBeNull();
+  });
+
+  it('タイムラインが末尾を超えた場合は最終セグメントの終端を返す', () => {
+    // 最終セグメント: hlsStart=5, duration=3 → HLS 終端は 8
+    expect(timelineToHls(100, segments)).toBe(8);
   });
 });


### PR DESCRIPTION
## 概要

Issue #181 の対応。HLS プレビュー（Issue #59 Step 2）として、フロントエンドのストアとフックを実装します。

## 変更内容

### `src/store/hlsPreviewStore.ts`（新規）
- `HlsSegment` 型定義
- `hlsToTimeline()` / `timelineToHls()` — HLS 時刻 ↔ タイムライン時刻の双方向変換ユーティリティ
- `useHlsPreviewStore` — HLS 状態管理ストア（`hlsPath`, `hlsSegments`, `isGenerating`, `error`）

### `src/hooks/useHlsPreview.ts`（新規）
- タイムラインの動画クリップ一覧を監視（Zustand subscribe）
- 変更後 1500ms のデバウンスで `generate_preview_hls` Tauri コマンドを呼び出し
- 成功時は `setHlsReady`、失敗時は `setError` でストアを更新

### `src/test/hlsPreviewStore.test.ts`（新規）
- `hlsToTimeline` / `timelineToHls` 合わせて 10 テストケース
- ギャップ区間・末尾超過のエッジケースを含む

## 依存関係

- Issue #180（Rust コマンド）が先行してマージ済み

## 手動テスト手順

- [x] `npm run test` で 630+ テストが全て通ること
- [x] `npm run lint` でエラーなし
- [x] `npm run build` でビルド成功
- [ ] Step 3（Issue #182）と統合後に VideoPreview での動作確認予定

## 関連 Issue

Closes #181