### PR TITLE
macOS About メニューを追加（Issue #188）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qcut",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "動画編集ソフトウェア",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "qcut"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "fern",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcut"
-version = "0.2.1"
+version = "0.3.0"
 description = "動画編集ソフトウェア"
 authors = ["ast"]
 license = "MIT"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,22 @@
 fn main() {
+  // ビルド時に git 情報を環境変数として埋め込む
+  // GIT_DESCRIBE: タグがあれば "v0.3.0" や "v0.3.0-3-gabcdef1"、なければ短縮ハッシュ
+  let git_describe = std::process::Command::new("git")
+    .args(["describe", "--tags", "--always", "--dirty"])
+    .output()
+    .ok()
+    .and_then(|o| {
+      if o.status.success() {
+        String::from_utf8(o.stdout).ok().map(|s| s.trim().to_string())
+      } else {
+        None
+      }
+    })
+    .unwrap_or_else(|| "unknown".to_string());
+
+  println!("cargo:rustc-env=GIT_DESCRIBE={}", git_describe);
+  println!("cargo:rerun-if-changed=../.git/HEAD");
+  println!("cargo:rerun-if-changed=../.git/refs/");
+
   tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use tauri::{Emitter, Manager};
-use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
+use tauri::menu::{AboutMetadata, CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
 
 /// カスタマイズ可能なメニューアイテムへの直接参照を保持する State
 struct CustomMenuItems(Mutex<HashMap<String, MenuItem<tauri::Wry>>>);
@@ -81,7 +81,7 @@ pub fn run() {
 
       if let Ok(sqlite_logger) = sqlite_logger::SqliteLogger::new(&db_path) {
         log_builder = log_builder.target(tauri_plugin_log::Target::new(
-          tauri_plugin_log::TargetKind::Dispatch(sqlite_logger.to_fern_dispatch(app_version)),
+          tauri_plugin_log::TargetKind::Dispatch(sqlite_logger.to_fern_dispatch(app_version.clone())),
         ));
       }
 
@@ -177,9 +177,30 @@ pub fn run() {
           &MenuItem::with_id(app, "help.shortcuts", "Keyboard Shortcuts", true, None::<&str>)?,
         ],
       )?;
+      let product_name = app.config().product_name.clone().unwrap_or_else(|| "qcut".to_string());
+      let app_menu = Submenu::with_items(
+        app,
+        &product_name,
+        true,
+        &[
+          &PredefinedMenuItem::about(app, None, Some(AboutMetadata {
+            name: Some(product_name.clone()),
+            version: Some(format!("{} ({})", app_version, env!("GIT_DESCRIBE"))),
+            ..Default::default()
+          }))?,
+          &PredefinedMenuItem::separator(app)?,
+          &PredefinedMenuItem::services(app, None)?,
+          &PredefinedMenuItem::separator(app)?,
+          &PredefinedMenuItem::hide(app, None)?,
+          &PredefinedMenuItem::hide_others(app, None)?,
+          &PredefinedMenuItem::show_all(app, None)?,
+          &PredefinedMenuItem::separator(app)?,
+          &PredefinedMenuItem::quit(app, None)?,
+        ],
+      )?;
       let menu = Menu::with_items(
         app,
-        &[&file_menu, &edit_menu, &timeline_menu, &view_menu, &plugins_menu, &help_menu],
+        &[&app_menu, &file_menu, &edit_menu, &timeline_menu, &view_menu, &plugins_menu, &help_menu],
       )?;
       app.set_menu(menu)?;
       app.on_menu_event(|app, event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "qcut",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "moe.qcut.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- macOS アプリメニューに About / Services / Hide / Quit 等の標準項目を追加
- About ダイアログにアプリ名・バージョン・git describe 情報を表示
- バージョンを v0.3.0 に更新（package.json, tauri.conf.json, Cargo.toml）

Closes #188

## 手動テスト手順
- [x] macOS でアプリを起動し、メニューバーの「qcut」をクリック
- [x] 「About qcut」が表示されること
- [x] クリックするとアプリ名・バージョン・git 情報が表示されること
- [x] Hide / Hide Others / Show All / Quit が動作すること