### PR TITLE
トーンカーブキーフレーム対応（Issue #160）

### DIFF
--- a/src/components/Inspector/EffectsPanel.tsx
+++ b/src/components/Inspector/EffectsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTimelineStore, DEFAULT_EFFECTS, DEFAULT_TONE_CURVES, DEFAULT_TIMECODE_OVERLAY } from '../../store/timelineStore';
-import type { ClipEffects, EasingType, Keyframe, ToneCurves, TimecodeOverlay } from '../../store/timelineStore';
+import type { ClipEffects, EasingType, Keyframe, ToneCurves, ToneCurveKeyframe, TimecodeOverlay } from '../../store/timelineStore';
 import { ColorWheelPanel } from './ColorWheelPanel';
 import { ColorPresetPanel } from './ColorPresetPanel';
 import { CurveEditor } from './CurveEditor';
@@ -135,6 +135,8 @@ export const EffectsPanel: React.FC = () => {
   const addKeyframe = useTimelineStore((s) => s.addKeyframe);
   const removeKeyframe = useTimelineStore((s) => s.removeKeyframe);
   const updateKeyframeEasingStore = useTimelineStore((s) => s.updateKeyframeEasing);
+  const addToneCurveKeyframe = useTimelineStore((s) => s.addToneCurveKeyframe);
+  const removeToneCurveKeyframe = useTimelineStore((s) => s.removeToneCurveKeyframe);
   const currentTime = useTimelineStore((s) => s.currentTime);
 
   const selectedClip = useMemo(() => {
@@ -156,9 +158,19 @@ export const EffectsPanel: React.FC = () => {
     return { ...DEFAULT_TIMECODE_OVERLAY, ...selectedClip?.timecodeOverlay };
   }, [selectedClip?.timecodeOverlay]);
 
+  const toneCurveKeyframes = useMemo(() => selectedClip?.toneCurveKeyframes ?? [], [selectedClip?.toneCurveKeyframes]);
+
+  const currentTcKf = useMemo(() => {
+    return toneCurveKeyframes.find((kf) => Math.abs(kf.time - clipLocalTime) <= 0.001) ?? null;
+  }, [toneCurveKeyframes, clipLocalTime]);
+
+  const hasTcKfAtCurrentTime = currentTcKf !== null;
+
+  // 現在時刻にKFがある場合はそのKFの値を表示、なければベースカーブ
   const toneCurves: ToneCurves = useMemo(() => {
+    if (currentTcKf) return { ...currentTcKf.toneCurves };
     return { ...DEFAULT_TONE_CURVES, ...selectedClip?.toneCurves };
-  }, [selectedClip?.toneCurves]);
+  }, [currentTcKf, selectedClip?.toneCurves]);
 
   const handleTimecodeChange = useCallback(
     (overlay: TimecodeOverlay) => {
@@ -170,17 +182,41 @@ export const EffectsPanel: React.FC = () => {
     [selectedTrackId, selectedClipId, updateClip],
   );
 
-  const handleCurveChange = useCallback(
-    (curves: ToneCurves) => {
-      if (!selectedTrackId || !selectedClipId) return;
-      updateClipSilent(selectedTrackId, selectedClipId, { toneCurves: curves });
-    },
-    [selectedTrackId, selectedClipId, updateClipSilent],
-  );
-
   const handleCurveCommit = useCallback(() => {
     commitHistory();
   }, [commitHistory]);
+
+  const handleCurveChange = useCallback(
+    (curves: ToneCurves) => {
+      if (!selectedTrackId || !selectedClipId) return;
+      // 現在時刻にトーンカーブKFが存在する場合はKF側を更新
+      if (currentTcKf) {
+        addToneCurveKeyframe(selectedTrackId, selectedClipId, {
+          time: currentTcKf.time,
+          toneCurves: { ...curves },
+          easing: currentTcKf.easing,
+        });
+      } else {
+        updateClipSilent(selectedTrackId, selectedClipId, { toneCurves: curves });
+      }
+    },
+    [selectedTrackId, selectedClipId, updateClipSilent, currentTcKf, addToneCurveKeyframe],
+  );
+
+  const handleAddToneCurveKeyframe = useCallback(() => {
+    if (!selectedTrackId || !selectedClipId) return;
+    const kf: ToneCurveKeyframe = {
+      time: Math.round(clipLocalTime * 100) / 100,
+      toneCurves: { ...toneCurves },
+      easing: 'linear',
+    };
+    addToneCurveKeyframe(selectedTrackId, selectedClipId, kf);
+  }, [selectedTrackId, selectedClipId, clipLocalTime, toneCurves, addToneCurveKeyframe]);
+
+  const handleRemoveToneCurveKeyframe = useCallback(() => {
+    if (!selectedTrackId || !selectedClipId) return;
+    removeToneCurveKeyframe(selectedTrackId, selectedClipId, clipLocalTime);
+  }, [selectedTrackId, selectedClipId, clipLocalTime, removeToneCurveKeyframe]);
 
   const handleChange = useCallback(
     (key: keyof ClipEffects, value: number) => {
@@ -240,6 +276,7 @@ export const EffectsPanel: React.FC = () => {
       effects: { ...DEFAULT_EFFECTS },
       keyframes: undefined,
       toneCurves: undefined,
+      toneCurveKeyframes: undefined,
     });
   }, [selectedTrackId, selectedClipId, updateClip]);
 
@@ -356,6 +393,27 @@ export const EffectsPanel: React.FC = () => {
 
           <CollapsibleSection id="toneCurve" title={t('effects.toneCurve')} defaultOpen={false} sections={sections} onToggle={handleToggleSection}>
             <CurveEditor toneCurves={toneCurves} onChange={handleCurveChange} onCommit={handleCurveCommit} />
+            <div style={{ display: 'flex', gap: '4px', marginTop: '6px', alignItems: 'center' }}>
+              <span style={{ fontSize: '11px', color: '#999' }}>{t('effects.keyframe')}</span>
+              {hasTcKfAtCurrentTime ? (
+                <button
+                  onClick={handleRemoveToneCurveKeyframe}
+                  style={{ fontSize: '11px', padding: '2px 6px', background: '#c9302c', color: '#fff', border: 'none', borderRadius: '3px', cursor: 'pointer' }}
+                >
+                  {t('effects.removeKeyframe')}
+                </button>
+              ) : (
+                <button
+                  onClick={handleAddToneCurveKeyframe}
+                  style={{ fontSize: '11px', padding: '2px 6px', background: '#444', color: '#fff', border: 'none', borderRadius: '3px', cursor: 'pointer' }}
+                >
+                  {t('effects.addKeyframe')}
+                </button>
+              )}
+              <span style={{ fontSize: '10px', color: '#666' }}>
+                ({toneCurveKeyframes.length} {t('effects.keyframeCount')})
+              </span>
+            </div>
           </CollapsibleSection>
 
           <CollapsibleSection id="colorWheel" title={t('effects.colorWheel')} defaultOpen={false} sections={sections} onToggle={handleToggleSection}>

--- a/src/components/Inspector/EffectsPanel.tsx
+++ b/src/components/Inspector/EffectsPanel.tsx
@@ -9,6 +9,7 @@ import { EffectPresetPanel } from './EffectPresetPanel';
 import { KeyframeRow } from './KeyframeRow';
 import { TimecodePanel } from './TimecodePanel';
 import { ScopesPanel } from '../Scopes/ScopesPanel';
+import { getEditableToneCurvesAtTime, hasActiveToneCurveKeyframes } from '../../utils/toneCurveKeyframes';
 import {
   BASIC_SLIDERS,
   HSL_SLIDERS,
@@ -168,12 +169,16 @@ export const EffectsPanel: React.FC = () => {
   }, [toneCurveKeyframes, snappedClipLocalTime]);
 
   const hasTcKfAtCurrentTime = currentTcKf !== null;
+  const hasActiveTcKfs = hasActiveToneCurveKeyframes(toneCurveKeyframes);
 
-  // 現在時刻にKFがある場合はそのKFの値を表示、なければベースカーブ
-  const toneCurves: ToneCurves = useMemo(() => {
-    if (currentTcKf) return { ...currentTcKf.toneCurves };
+  const baseToneCurves: ToneCurves = useMemo(() => {
     return { ...DEFAULT_TONE_CURVES, ...selectedClip?.toneCurves };
-  }, [currentTcKf, selectedClip?.toneCurves]);
+  }, [selectedClip?.toneCurves]);
+
+  // 現在時刻に見えているトーンカーブをエディタ表示に使う
+  const toneCurves: ToneCurves = useMemo(() => {
+    return getEditableToneCurvesAtTime(toneCurveKeyframes, baseToneCurves, snappedClipLocalTime);
+  }, [toneCurveKeyframes, baseToneCurves, snappedClipLocalTime]);
 
   const handleTimecodeChange = useCallback(
     (overlay: TimecodeOverlay) => {
@@ -200,11 +205,21 @@ export const EffectsPanel: React.FC = () => {
             : kf,
         );
         updateClipSilent(selectedTrackId, selectedClipId, { toneCurveKeyframes: updated });
+      } else if (hasActiveTcKfs) {
+        const updated = [
+          ...toneCurveKeyframes,
+          {
+            time: snappedClipLocalTime,
+            toneCurves: { ...curves },
+            easing: 'linear',
+          },
+        ].sort((a, b) => a.time - b.time);
+        updateClipSilent(selectedTrackId, selectedClipId, { toneCurveKeyframes: updated });
       } else {
         updateClipSilent(selectedTrackId, selectedClipId, { toneCurves: curves });
       }
     },
-    [selectedTrackId, selectedClipId, updateClipSilent, currentTcKf, toneCurveKeyframes],
+    [selectedTrackId, selectedClipId, updateClipSilent, currentTcKf, hasActiveTcKfs, toneCurveKeyframes, snappedClipLocalTime],
   );
 
   const handleAddToneCurveKeyframe = useCallback(() => {

--- a/src/components/Inspector/EffectsPanel.tsx
+++ b/src/components/Inspector/EffectsPanel.tsx
@@ -160,9 +160,12 @@ export const EffectsPanel: React.FC = () => {
 
   const toneCurveKeyframes = useMemo(() => selectedClip?.toneCurveKeyframes ?? [], [selectedClip?.toneCurveKeyframes]);
 
+  // KF追加時と同じ丸めを適用して一致判定の基準を統一
+  const snappedClipLocalTime = Math.round(clipLocalTime * 100) / 100;
+
   const currentTcKf = useMemo(() => {
-    return toneCurveKeyframes.find((kf) => Math.abs(kf.time - clipLocalTime) <= 0.001) ?? null;
-  }, [toneCurveKeyframes, clipLocalTime]);
+    return toneCurveKeyframes.find((kf) => Math.abs(kf.time - snappedClipLocalTime) <= 0.001) ?? null;
+  }, [toneCurveKeyframes, snappedClipLocalTime]);
 
   const hasTcKfAtCurrentTime = currentTcKf !== null;
 
@@ -189,34 +192,35 @@ export const EffectsPanel: React.FC = () => {
   const handleCurveChange = useCallback(
     (curves: ToneCurves) => {
       if (!selectedTrackId || !selectedClipId) return;
-      // 現在時刻にトーンカーブKFが存在する場合はKF側を更新
+      // 現在時刻にトーンカーブKFが存在する場合はKF配列を直接更新（履歴に積まない）
       if (currentTcKf) {
-        addToneCurveKeyframe(selectedTrackId, selectedClipId, {
-          time: currentTcKf.time,
-          toneCurves: { ...curves },
-          easing: currentTcKf.easing,
-        });
+        const updated = toneCurveKeyframes.map((kf) =>
+          Math.abs(kf.time - currentTcKf.time) <= 0.001
+            ? { ...kf, toneCurves: { ...curves } }
+            : kf,
+        );
+        updateClipSilent(selectedTrackId, selectedClipId, { toneCurveKeyframes: updated });
       } else {
         updateClipSilent(selectedTrackId, selectedClipId, { toneCurves: curves });
       }
     },
-    [selectedTrackId, selectedClipId, updateClipSilent, currentTcKf, addToneCurveKeyframe],
+    [selectedTrackId, selectedClipId, updateClipSilent, currentTcKf, toneCurveKeyframes],
   );
 
   const handleAddToneCurveKeyframe = useCallback(() => {
     if (!selectedTrackId || !selectedClipId) return;
     const kf: ToneCurveKeyframe = {
-      time: Math.round(clipLocalTime * 100) / 100,
+      time: snappedClipLocalTime,
       toneCurves: { ...toneCurves },
       easing: 'linear',
     };
     addToneCurveKeyframe(selectedTrackId, selectedClipId, kf);
-  }, [selectedTrackId, selectedClipId, clipLocalTime, toneCurves, addToneCurveKeyframe]);
+  }, [selectedTrackId, selectedClipId, snappedClipLocalTime, toneCurves, addToneCurveKeyframe]);
 
   const handleRemoveToneCurveKeyframe = useCallback(() => {
     if (!selectedTrackId || !selectedClipId) return;
-    removeToneCurveKeyframe(selectedTrackId, selectedClipId, clipLocalTime);
-  }, [selectedTrackId, selectedClipId, clipLocalTime, removeToneCurveKeyframe]);
+    removeToneCurveKeyframe(selectedTrackId, selectedClipId, snappedClipLocalTime);
+  }, [selectedTrackId, selectedClipId, snappedClipLocalTime, removeToneCurveKeyframe]);
 
   const handleChange = useCallback(
     (key: keyof ClipEffects, value: number) => {

--- a/src/components/Timeline/Clip.tsx
+++ b/src/components/Timeline/Clip.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { WaveformCanvas } from './WaveformCanvas';
 import { useDragClip } from './useDragClip';
 import { ClipContextMenu } from './ClipContextMenu';
-import { calculateClipPosition, calculateContextMenuTime } from './clipUtils';
+import { calculateClipPosition, calculateContextMenuTime, collectToneCurveMarkerTimes } from './clipUtils';
 
 interface ClipProps {
   clip: ClipType;
@@ -52,6 +52,11 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
     }
     return Array.from(times).sort((a, b) => a - b);
   }, [clip.keyframes]);
+
+  const toneCurveMarkerTimes = useMemo(
+    () => collectToneCurveMarkerTimes(clip.toneCurveKeyframes),
+    [clip.toneCurveKeyframes],
+  );
 
   const kfDragRef = useRef<KfDragState | null>(null);
   const [kfDragPreview, setKfDragPreview] = useState<{ original: number; current: number } | null>(null);
@@ -111,13 +116,25 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
     e.preventDefault();
     useTimelineStore.getState().deleteKeyframesAtTime(trackId, clip.id, time);
   };
+
+  const handleToneCurveMarkerClick = (e: React.MouseEvent, time: number) => {
+    e.stopPropagation();
+    const absoluteTime = clip.startTime + time;
+    useTimelineStore.getState().setSelectedClip(trackId, clip.id);
+    useTimelineStore.getState().setCurrentTime(absoluteTime);
+    useVideoPreviewStore.getState().setCurrentTime(absoluteTime);
+  };
   // --- end keyframe markers ---
 
   const handleMouseDown = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
     if (e.button === 0) {
       // 削除ボタン・キーフレームマーカーはドラッグ対象外
-      if (target.classList.contains('clip-delete') || target.classList.contains('clip-keyframe-marker')) {
+      if (
+        target.classList.contains('clip-delete')
+        || target.classList.contains('clip-keyframe-marker')
+        || target.classList.contains('clip-tonecurve-marker')
+      ) {
         setSelectedClip(trackId, clip.id);
         return;
       }
@@ -205,6 +222,17 @@ function Clip({ clip, trackId, trackType }: ClipProps) {
             />
           );
         })}
+
+        {toneCurveMarkerTimes.map(time => (
+          <button
+            key={`tonecurve-${time}`}
+            type="button"
+            className="clip-tonecurve-marker"
+            style={{ left: `${time * pixelsPerSecond}px` }}
+            onClick={(e) => handleToneCurveMarkerClick(e, time)}
+            title={`Tone Curve ${time.toFixed(2)}s`}
+          />
+        ))}
       </div>
 
       {showContextMenu && (

--- a/src/components/Timeline/Timeline.css
+++ b/src/components/Timeline/Timeline.css
@@ -459,6 +459,25 @@
   z-index: 10;
 }
 
+.clip-tonecurve-marker {
+  position: absolute;
+  top: 4px;
+  width: 8px;
+  height: 8px;
+  padding: 0;
+  background-color: #ff6b6b;
+  border: 1px solid rgba(0, 0, 0, 0.45);
+  border-radius: 999px;
+  transform: translateX(-50%);
+  cursor: pointer;
+  z-index: 3;
+}
+
+.clip-tonecurve-marker:hover {
+  background-color: #ffc0c0;
+  border-color: #ff6b6b;
+}
+
 /* トランジションインジケーター */
 .transition-indicator {
   position: absolute;
@@ -768,4 +787,3 @@
   background-color: #4a9eff;
   color: #fff;
 }
-

--- a/src/components/Timeline/clipUtils.ts
+++ b/src/components/Timeline/clipUtils.ts
@@ -2,6 +2,8 @@
  * Clip コンポーネントおよび関連フック内で使われる純粋な計算ロジック
  */
 
+import type { ToneCurveKeyframe } from '../../store/timelineStore';
+
 // --- Snap types ---
 
 export interface SnapResult {
@@ -49,6 +51,18 @@ export function calculateContextMenuTime(
 ): number {
   const relTime = relativeX / pixelsPerSecond;
   return clipStartTime + Math.max(0, Math.min(relTime, clipDuration));
+}
+
+/**
+ * トーンカーブキーフレーム時刻を昇順に返す。
+ */
+export function collectToneCurveMarkerTimes(
+  toneCurveKeyframes?: ToneCurveKeyframe[],
+): number[] {
+  if (!toneCurveKeyframes || toneCurveKeyframes.length === 0) return [];
+  return toneCurveKeyframes
+    .map((kf) => kf.time)
+    .sort((a, b) => a - b);
 }
 
 // --- Snap functions ---

--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -176,6 +176,16 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
     setIsVideoReady(video.readyState >= 2 && video.currentSrc === currentVideoUrl);
   }, [activeVideoRef, currentVideoUrl, videoRef]);
 
+  // 停止中にタイムライン上で時刻を変更した場合も canvas preview を再描画する
+  useEffect(() => {
+    return useTimelineStore.subscribe((state, prevState) => {
+      if (state.currentTime === prevState.currentTime) return;
+      currentTimeRef.current = state.currentTime;
+      if (state.isPlaying || !needsCanvas) return;
+      renderCanvasFrame();
+    });
+  }, [needsCanvas, renderCanvasFrame]);
+
   const { captureFrame } = useFrameCapture({
     videoRef: activeVideoRef,
     pipelineRef,

--- a/src/components/VideoPreview/canvasEffects.ts
+++ b/src/components/VideoPreview/canvasEffects.ts
@@ -355,11 +355,20 @@ export function initWebGLPipeline(canvas: HTMLCanvasElement): WebGLPipeline | nu
   return { gl, program, texture, curveLUTTexture, uniforms, readBuf: null, readBufSize: 0 };
 }
 
+/** キーフレーム補間で事前計算された LUT（Float32Array, 各256要素） */
+export interface PrecomputedLUTs {
+  rgbLUT: Float32Array;
+  rLUT: Float32Array;
+  gLUT: Float32Array;
+  bLUT: Float32Array;
+}
+
 export function renderFrame(
   pipeline: WebGLPipeline,
   video: HTMLVideoElement,
   effects: ClipEffects,
   toneCurves?: ToneCurves,
+  precomputedLUTs?: PrecomputedLUTs,
 ): void {
   // Skip if video is not ready (HAVE_CURRENT_DATA = 2)
   if (video.readyState < 2) return;
@@ -383,13 +392,17 @@ export function renderFrame(
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
 
   // Upload curve LUT texture
-  const curveActive = hasCurveActive(toneCurves);
-  if (curveActive && toneCurves) {
-    const lutData = buildCurveLUTTexture(toneCurves);
-    gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, curveLUTTexture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, lutData);
-    gl.activeTexture(gl.TEXTURE0);
+  const curveActive = precomputedLUTs ? true : hasCurveActive(toneCurves);
+  if (curveActive) {
+    const lutData = precomputedLUTs
+      ? buildLUTTextureFromFloat32(precomputedLUTs)
+      : toneCurves ? buildCurveLUTTexture(toneCurves) : null;
+    if (lutData) {
+      gl.activeTexture(gl.TEXTURE1);
+      gl.bindTexture(gl.TEXTURE_2D, curveLUTTexture);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, lutData);
+      gl.activeTexture(gl.TEXTURE0);
+    }
   }
   gl.uniform1f(uniforms['u_curveEnabled'], curveActive ? 1.0 : 0.0);
 
@@ -424,6 +437,17 @@ export function renderFrame(
  */
 let _cachedToneCurves: ToneCurves | null = null;
 let _cachedLUTData: Uint8Array | null = null;
+
+function buildLUTTextureFromFloat32(luts: PrecomputedLUTs): Uint8Array {
+  const data = new Uint8Array(256 * 4);
+  for (let i = 0; i < 256; i++) {
+    data[i * 4 + 0] = Math.round(luts.rLUT[i] * 255);
+    data[i * 4 + 1] = Math.round(luts.gLUT[i] * 255);
+    data[i * 4 + 2] = Math.round(luts.bLUT[i] * 255);
+    data[i * 4 + 3] = Math.round(luts.rgbLUT[i] * 255);
+  }
+  return data;
+}
 
 function buildCurveLUTTexture(toneCurves: ToneCurves): Uint8Array {
   if (_cachedToneCurves === toneCurves && _cachedLUTData) {

--- a/src/components/VideoPreview/canvasEffects.ts
+++ b/src/components/VideoPreview/canvasEffects.ts
@@ -438,15 +438,16 @@ export function renderFrame(
 let _cachedToneCurves: ToneCurves | null = null;
 let _cachedLUTData: Uint8Array | null = null;
 
+const _precomputedLUTBuffer = new Uint8Array(256 * 4);
+
 function buildLUTTextureFromFloat32(luts: PrecomputedLUTs): Uint8Array {
-  const data = new Uint8Array(256 * 4);
   for (let i = 0; i < 256; i++) {
-    data[i * 4 + 0] = Math.round(luts.rLUT[i] * 255);
-    data[i * 4 + 1] = Math.round(luts.gLUT[i] * 255);
-    data[i * 4 + 2] = Math.round(luts.bLUT[i] * 255);
-    data[i * 4 + 3] = Math.round(luts.rgbLUT[i] * 255);
+    _precomputedLUTBuffer[i * 4 + 0] = Math.round(luts.rLUT[i] * 255);
+    _precomputedLUTBuffer[i * 4 + 1] = Math.round(luts.gLUT[i] * 255);
+    _precomputedLUTBuffer[i * 4 + 2] = Math.round(luts.bLUT[i] * 255);
+    _precomputedLUTBuffer[i * 4 + 3] = Math.round(luts.rgbLUT[i] * 255);
   }
-  return data;
+  return _precomputedLUTBuffer;
 }
 
 function buildCurveLUTTexture(toneCurves: ToneCurves): Uint8Array {

--- a/src/components/VideoPreview/useCanvasRenderer.ts
+++ b/src/components/VideoPreview/useCanvasRenderer.ts
@@ -5,6 +5,7 @@ import type { WebGLPipeline } from './canvasEffects';
 import { needsCanvasPipeline, initWebGLPipeline, renderFrame, destroyPipeline } from './canvasEffects';
 import type { Clip as ClipType } from '../../store/timelineStore';
 import { getEffectsAtTime, hasActiveKeyframes } from '../../utils/keyframes';
+import { getToneCurvesAtTime, hasActiveToneCurveKeyframes } from '../../utils/toneCurveKeyframes';
 import { logAction } from '../../store/actionLogger';
 import { useVideoPreviewStore } from '../../store/videoPreviewStore';
 
@@ -45,7 +46,9 @@ export const useCanvasRenderer = ({
     [currentClip?.toneCurves],
   );
   // キーフレームがある場合は常に canvas を使用（保守的）
-  const needsCanvas = needsCanvasPipeline(baseEffects, baseToneCurves) || (currentClip ? hasActiveKeyframes(currentClip) : false);
+  const needsCanvas = needsCanvasPipeline(baseEffects, baseToneCurves)
+    || (currentClip ? hasActiveKeyframes(currentClip) : false)
+    || (currentClip ? hasActiveToneCurveKeyframes(currentClip.toneCurveKeyframes) : false);
 
   // renderCanvasFrame 内で最新の currentClip / needsCanvas を参照するための ref
   const currentClipRef = useRef(currentClip);
@@ -86,7 +89,8 @@ export const useCanvasRenderer = ({
 
     // キーフレームがアクティブな場合、canvas がビデオを隠しているため
     // WebGL 専用エフェクトがなくても必ず描画する（早期リターンしない）
-    if (!needsCanvasPipeline(effects, currentClipRef.current?.toneCurves ?? DEFAULT_TONE_CURVES) && !activeKf) {
+    const activeTcKf = hasActiveToneCurveKeyframes(currentClipRef.current?.toneCurveKeyframes);
+    if (!needsCanvasPipeline(effects, currentClipRef.current?.toneCurves ?? DEFAULT_TONE_CURVES) && !activeKf && !activeTcKf) {
       return;
     }
 
@@ -97,7 +101,20 @@ export const useCanvasRenderer = ({
     if (!pipelineRef.current) return;
 
     const tc = currentClipRef.current?.toneCurves ?? DEFAULT_TONE_CURVES;
-    renderFrame(pipelineRef.current, videoRef.current, effects, tc);
+
+    // トーンカーブキーフレームがアクティブなら補間済み LUT を使用
+    const tcKfs = currentClipRef.current?.toneCurveKeyframes;
+    let precomputedLUTs: { rgbLUT: Float32Array; rLUT: Float32Array; gLUT: Float32Array; bLUT: Float32Array } | undefined;
+    if (hasActiveToneCurveKeyframes(tcKfs)) {
+      const timelineTime = kfDragPreviewTimeRef.current ?? currentTimeRef.current;
+      const clipLocalTime = timelineTime - (currentClipRef.current?.startTime ?? 0);
+      const interpolated = getToneCurvesAtTime(tcKfs!, clipLocalTime);
+      if (interpolated) {
+        precomputedLUTs = interpolated;
+      }
+    }
+
+    renderFrame(pipelineRef.current, videoRef.current, effects, precomputedLUTs ? undefined : tc, precomputedLUTs);
   }, [videoRef, canvasRef, currentTimeRef]);
 
   // Re-render when effects change while paused (clip の変更にも追従)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,7 +89,11 @@
     "monochrome": "Monochrome",
     "toneCurve": "Tone Curves",
     "curveReset": "Reset",
-    "curveResetAll": "Reset All"
+    "curveResetAll": "Reset All",
+    "keyframe": "Keyframe",
+    "addKeyframe": "Add",
+    "removeKeyframe": "Remove",
+    "keyframeCount": "keys"
   },
   "transform": {
     "title": "Transform",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -89,7 +89,11 @@
     "monochrome": "モノクロ",
     "toneCurve": "トーンカーブ",
     "curveReset": "リセット",
-    "curveResetAll": "全チャンネルリセット"
+    "curveResetAll": "全チャンネルリセット",
+    "keyframe": "キーフレーム",
+    "addKeyframe": "追加",
+    "removeKeyframe": "削除",
+    "keyframeCount": "個"
   },
   "transform": {
     "title": "トランスフォーム",

--- a/src/store/timeline/clipSlice.ts
+++ b/src/store/timeline/clipSlice.ts
@@ -1,6 +1,6 @@
 import type { StoreApi } from 'zustand';
 import { logAction } from '../actionLogger';
-import type { TimelineState, Clip, ClipTransition, ClipEffects, Keyframe, EasingType } from './types';
+import type { TimelineState, Clip, ClipTransition, ClipEffects, Keyframe, EasingType, ToneCurveKeyframe } from './types';
 import { withHistory } from './historySlice';
 
 type Set = StoreApi<TimelineState>['setState'];
@@ -279,6 +279,63 @@ export const createClipSlice = (set: Set) => ({
               }
               const hasKeys = Object.keys(newKeyframes).length > 0;
               return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
+            }),
+          }
+        : track
+    );
+    return withHistory(state, newTracks);
+  }),
+
+  addToneCurveKeyframe: (trackId: string, clipId: string, keyframe: ToneCurveKeyframe) => set((state) => {
+    logAction('addToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${keyframe.time.toFixed(2)}`);
+    const newTracks = state.tracks.map(track =>
+      track.id === trackId
+        ? {
+            ...track,
+            clips: track.clips.map(clip => {
+              if (clip.id !== clipId) return clip;
+              const existing = clip.toneCurveKeyframes ?? [];
+              const filtered = existing.filter(kf => Math.abs(kf.time - keyframe.time) > 0.001);
+              const updated = [...filtered, keyframe].sort((a, b) => a.time - b.time);
+              return { ...clip, toneCurveKeyframes: updated };
+            }),
+          }
+        : track
+    );
+    return withHistory(state, newTracks);
+  }),
+
+  removeToneCurveKeyframe: (trackId: string, clipId: string, time: number) => set((state) => {
+    logAction('removeToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
+    const newTracks = state.tracks.map(track =>
+      track.id === trackId
+        ? {
+            ...track,
+            clips: track.clips.map(clip => {
+              if (clip.id !== clipId) return clip;
+              const existing = clip.toneCurveKeyframes ?? [];
+              const updated = existing.filter(kf => Math.abs(kf.time - time) > 0.001);
+              return { ...clip, toneCurveKeyframes: updated.length > 0 ? updated : undefined };
+            }),
+          }
+        : track
+    );
+    return withHistory(state, newTracks);
+  }),
+
+  updateToneCurveKeyframeEasing: (trackId: string, clipId: string, time: number, easing: EasingType) => set((state) => {
+    logAction('updateToneCurveKeyframeEasing', `track=${trackId} clip=${clipId} time=${time.toFixed(2)} easing=${easing}`);
+    const newTracks = state.tracks.map(track =>
+      track.id === trackId
+        ? {
+            ...track,
+            clips: track.clips.map(clip => {
+              if (clip.id !== clipId) return clip;
+              const existing = clip.toneCurveKeyframes ?? [];
+              const updated = existing.map(kf =>
+                Math.abs(kf.time - time) <= 0.001 ? { ...kf, easing } : kf
+              );
+              return { ...clip, toneCurveKeyframes: updated };
             }),
           }
         : track

--- a/src/store/timeline/index.ts
+++ b/src/store/timeline/index.ts
@@ -20,6 +20,7 @@ export type {
   EasingType,
   Keyframe,
   ClipKeyframes,
+  ToneCurveKeyframe,
   CurvePoint,
   ToneCurves,
   TextAnimation,

--- a/src/store/timeline/types.ts
+++ b/src/store/timeline/types.ts
@@ -121,6 +121,13 @@ export interface Keyframe {
 
 export type ClipKeyframes = Partial<Record<keyof ClipEffects, Keyframe[]>>;
 
+/** トーンカーブ用キーフレーム（LUT ベースで補間） */
+export interface ToneCurveKeyframe {
+  time: number;         // クリップ先頭からの秒数 (0 〜 clip.duration)
+  toneCurves: ToneCurves;
+  easing: EasingType;   // このキーフレームから次への補間方式
+}
+
 // --- Text types ---
 
 export type TextAnimation = 'none' | 'fadeIn' | 'fadeOut' | 'fadeInOut' | 'slideUp' | 'slideDown';
@@ -213,6 +220,9 @@ export interface Clip {
   // トーンカーブ
   toneCurves?: ToneCurves;
 
+  // トーンカーブキーフレーム（LUT ベース補間）
+  toneCurveKeyframes?: ToneCurveKeyframe[];
+
   // テキストオーバーレイ
   textProperties?: TextProperties;
 
@@ -279,6 +289,9 @@ export interface ClipSlice {
   updateKeyframeEasing: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number, easing: EasingType) => void;
   moveKeyframes: (trackId: string, clipId: string, fromTime: number, toTime: number) => void;
   deleteKeyframesAtTime: (trackId: string, clipId: string, time: number) => void;
+  addToneCurveKeyframe: (trackId: string, clipId: string, keyframe: ToneCurveKeyframe) => void;
+  removeToneCurveKeyframe: (trackId: string, clipId: string, time: number) => void;
+  updateToneCurveKeyframeEasing: (trackId: string, clipId: string, time: number, easing: EasingType) => void;
 }
 
 export interface HistorySlice {

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -7,6 +7,7 @@ export type {
   EasingType,
   Keyframe,
   ClipKeyframes,
+  ToneCurveKeyframe,
   CurvePoint,
   ToneCurves,
   TextAnimation,

--- a/src/test/clipUtils.test.ts
+++ b/src/test/clipUtils.test.ts
@@ -3,10 +3,12 @@ import {
   calculateDragNewStartTime,
   calculateClipPosition,
   calculateContextMenuTime,
+  collectToneCurveMarkerTimes,
   clampMenuPosition,
   collectSnapTargets,
   applySnap,
 } from '../components/Timeline/clipUtils';
+import type { ToneCurveKeyframe } from '../store/timelineStore';
 
 describe('calculateDragNewStartTime', () => {
   it('正の方向へのドラッグで開始時間が増加する', () => {
@@ -82,6 +84,23 @@ describe('calculateContextMenuTime', () => {
     // relX=600 → relTime=12 → min(12, 10) = 10 → 5+10=15
     const result = calculateContextMenuTime(5, 10, 600, 50);
     expect(result).toBe(15);
+  });
+});
+
+describe('collectToneCurveMarkerTimes', () => {
+  it('トーンカーブキーフレーム時刻を昇順で返す', () => {
+    const keyframes: ToneCurveKeyframe[] = [
+      { time: 4, toneCurves: { rgb: [], r: [], g: [], b: [] }, easing: 'linear' },
+      { time: 1.5, toneCurves: { rgb: [], r: [], g: [], b: [] }, easing: 'linear' },
+      { time: 2, toneCurves: { rgb: [], r: [], g: [], b: [] }, easing: 'linear' },
+    ];
+
+    expect(collectToneCurveMarkerTimes(keyframes)).toEqual([1.5, 2, 4]);
+  });
+
+  it('キーフレームがない場合は空配列を返す', () => {
+    expect(collectToneCurveMarkerTimes(undefined)).toEqual([]);
+    expect(collectToneCurveMarkerTimes([])).toEqual([]);
   });
 });
 

--- a/src/test/timelineStoreActions.test.ts
+++ b/src/test/timelineStoreActions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useTimelineStore } from '../store/timelineStore';
-import type { Clip, Track } from '../store/timelineStore';
+import type { Clip, Track, ToneCurveKeyframe } from '../store/timelineStore';
+import { DEFAULT_EFFECTS } from '../store/timelineStore';
 
 function resetStore() {
   useTimelineStore.setState({
@@ -429,5 +430,93 @@ describe('undo/redo clears selection', () => {
     const state = useTimelineStore.getState();
     expect(state.selectedClipId).toBeNull();
     expect(state.selectedTrackId).toBeNull();
+  });
+});
+
+describe('toneCurveKeyframes store operations', () => {
+  beforeEach(resetStore);
+
+  const makeTcKf = (time: number): ToneCurveKeyframe => ({
+    time,
+    toneCurves: {
+      rgb: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+      r: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+      g: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+      b: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+    },
+    easing: 'linear',
+  });
+
+  it('addToneCurveKeyframe should add a keyframe to the clip', () => {
+    addVideoTrackWithClip();
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(0));
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(4));
+    const clip = getClip('v1', 'clip-1');
+    expect(clip?.toneCurveKeyframes).toHaveLength(2);
+    expect(clip?.toneCurveKeyframes![0].time).toBe(0);
+    expect(clip?.toneCurveKeyframes![1].time).toBe(4);
+  });
+
+  it('addToneCurveKeyframe should overwrite keyframe at same time', () => {
+    addVideoTrackWithClip();
+    const kf1 = makeTcKf(2);
+    const kf2: ToneCurveKeyframe = {
+      ...makeTcKf(2),
+      toneCurves: {
+        rgb: [{ x: 0, y: 0.5 }, { x: 1, y: 0.5 }],
+        r: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+        g: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+        b: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+      },
+    };
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', kf1);
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', kf2);
+    const clip = getClip('v1', 'clip-1');
+    expect(clip?.toneCurveKeyframes).toHaveLength(1);
+    expect(clip?.toneCurveKeyframes![0].toneCurves.rgb[0].y).toBe(0.5);
+  });
+
+  it('removeToneCurveKeyframe should remove the keyframe at given time', () => {
+    addVideoTrackWithClip();
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(0));
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(4));
+    useTimelineStore.getState().removeToneCurveKeyframe('v1', 'clip-1', 0);
+    const clip = getClip('v1', 'clip-1');
+    expect(clip?.toneCurveKeyframes).toHaveLength(1);
+    expect(clip?.toneCurveKeyframes![0].time).toBe(4);
+  });
+
+  it('removeToneCurveKeyframe should set undefined when all keyframes removed', () => {
+    addVideoTrackWithClip();
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(2));
+    useTimelineStore.getState().removeToneCurveKeyframe('v1', 'clip-1', 2);
+    const clip = getClip('v1', 'clip-1');
+    expect(clip?.toneCurveKeyframes).toBeUndefined();
+  });
+
+  it('updateToneCurveKeyframeEasing should update easing type', () => {
+    addVideoTrackWithClip();
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(1));
+    useTimelineStore.getState().updateToneCurveKeyframeEasing('v1', 'clip-1', 1, 'easeIn');
+    const clip = getClip('v1', 'clip-1');
+    expect(clip?.toneCurveKeyframes![0].easing).toBe('easeIn');
+  });
+
+  // Bug fix #3: リセットで toneCurveKeyframes が消えることを検証
+  it('updateClip with toneCurveKeyframes: undefined should clear keyframes (reset scenario)', () => {
+    addVideoTrackWithClip();
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(0));
+    useTimelineStore.getState().addToneCurveKeyframe('v1', 'clip-1', makeTcKf(4));
+    // リセット相当の操作
+    useTimelineStore.getState().updateClip('v1', 'clip-1', {
+      effects: { ...DEFAULT_EFFECTS },
+      keyframes: undefined,
+      toneCurves: undefined,
+      toneCurveKeyframes: undefined,
+    });
+    const clip = getClip('v1', 'clip-1');
+    expect(clip?.toneCurveKeyframes).toBeUndefined();
+    expect(clip?.toneCurves).toBeUndefined();
+    expect(clip?.keyframes).toBeUndefined();
   });
 });

--- a/src/test/toneCurveKeyframes.test.ts
+++ b/src/test/toneCurveKeyframes.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  interpolateToneCurveLUTs,
+  getToneCurvesAtTime,
+  hasActiveToneCurveKeyframes,
+} from '../utils/toneCurveKeyframes';
+import type { ToneCurves, ToneCurveKeyframe, CurvePoint } from '../store/timeline/types';
+import { DEFAULT_TONE_CURVES } from '../store/timeline/types';
+
+const linearCurve: CurvePoint[] = [
+  { x: 0, y: 0 },
+  { x: 1, y: 1 },
+];
+
+const brightCurve: CurvePoint[] = [
+  { x: 0, y: 0.2 },
+  { x: 1, y: 1 },
+];
+
+const darkCurve: CurvePoint[] = [
+  { x: 0, y: 0 },
+  { x: 1, y: 0.8 },
+];
+
+const makeToneCurves = (rgb: CurvePoint[]): ToneCurves => ({
+  rgb,
+  r: [...linearCurve],
+  g: [...linearCurve],
+  b: [...linearCurve],
+});
+
+describe('interpolateToneCurveLUTs', () => {
+  it('should return LUT A when t=0', () => {
+    const lutA = new Float32Array([0, 0.5, 1.0]);
+    const lutB = new Float32Array([0.2, 0.7, 0.8]);
+    const result = interpolateToneCurveLUTs(lutA, lutB, 0);
+    expect(result[0]).toBeCloseTo(0);
+    expect(result[1]).toBeCloseTo(0.5);
+    expect(result[2]).toBeCloseTo(1.0);
+  });
+
+  it('should return LUT B when t=1', () => {
+    const lutA = new Float32Array([0, 0.5, 1.0]);
+    const lutB = new Float32Array([0.2, 0.7, 0.8]);
+    const result = interpolateToneCurveLUTs(lutA, lutB, 1);
+    expect(result[0]).toBeCloseTo(0.2);
+    expect(result[1]).toBeCloseTo(0.7);
+    expect(result[2]).toBeCloseTo(0.8);
+  });
+
+  it('should linearly interpolate LUT values at t=0.5', () => {
+    const lutA = new Float32Array([0, 0.4, 1.0]);
+    const lutB = new Float32Array([0.2, 0.8, 0.6]);
+    const result = interpolateToneCurveLUTs(lutA, lutB, 0.5);
+    expect(result[0]).toBeCloseTo(0.1);
+    expect(result[1]).toBeCloseTo(0.6);
+    expect(result[2]).toBeCloseTo(0.8);
+  });
+
+  it('should handle t=0.25', () => {
+    const lutA = new Float32Array([0, 1.0]);
+    const lutB = new Float32Array([1.0, 0]);
+    const result = interpolateToneCurveLUTs(lutA, lutB, 0.25);
+    expect(result[0]).toBeCloseTo(0.25);
+    expect(result[1]).toBeCloseTo(0.75);
+  });
+});
+
+describe('getToneCurvesAtTime', () => {
+  it('should return null for empty keyframes', () => {
+    expect(getToneCurvesAtTime([], 1.0)).toBeNull();
+  });
+
+  it('should return null for single keyframe (not enough for interpolation)', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 1.0, toneCurves: makeToneCurves(brightCurve), easing: 'linear' },
+    ];
+    expect(getToneCurvesAtTime(kfs, 1.0)).toBeNull();
+  });
+
+  it('should return first keyframe curves when time is before first keyframe', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 2.0, toneCurves: makeToneCurves(brightCurve), easing: 'linear' },
+      { time: 4.0, toneCurves: makeToneCurves(darkCurve), easing: 'linear' },
+    ];
+    const result = getToneCurvesAtTime(kfs, 0);
+    expect(result).not.toBeNull();
+    expect(result!.rgb).toEqual(brightCurve);
+  });
+
+  it('should return last keyframe curves when time is after last keyframe', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 2.0, toneCurves: makeToneCurves(brightCurve), easing: 'linear' },
+      { time: 4.0, toneCurves: makeToneCurves(darkCurve), easing: 'linear' },
+    ];
+    const result = getToneCurvesAtTime(kfs, 5.0);
+    expect(result).not.toBeNull();
+    expect(result!.rgb).toEqual(darkCurve);
+  });
+
+  it('should interpolate LUTs between two keyframes at midpoint', () => {
+    const curvesA = makeToneCurves(linearCurve);
+    const curvesB: ToneCurves = {
+      rgb: [{ x: 0, y: 0.5 }, { x: 1, y: 0.5 }], // flat at 0.5
+      r: [...linearCurve],
+      g: [...linearCurve],
+      b: [...linearCurve],
+    };
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: curvesA, easing: 'linear' },
+      { time: 4, toneCurves: curvesB, easing: 'linear' },
+    ];
+    const result = getToneCurvesAtTime(kfs, 2.0);
+    expect(result).not.toBeNull();
+    // At t=0.5, the interpolated LUT should be between linear and flat-0.5
+    // For index 0 (input 0): linear gives 0, flat gives 0.5 → 0.25
+    expect(result!.rgbLUT[0]).toBeCloseTo(0.25, 1);
+    // For index 255 (input 1): linear gives 1, flat gives 0.5 → 0.75
+    expect(result!.rgbLUT[255]).toBeCloseTo(0.75, 1);
+  });
+
+  it('should interpolate all four channels independently', () => {
+    const curvesA: ToneCurves = {
+      rgb: [...linearCurve],
+      r: [{ x: 0, y: 0 }, { x: 1, y: 0.5 }],
+      g: [...linearCurve],
+      b: [...linearCurve],
+    };
+    const curvesB: ToneCurves = {
+      rgb: [...linearCurve],
+      r: [{ x: 0, y: 0 }, { x: 1, y: 1.0 }],
+      g: [...linearCurve],
+      b: [...linearCurve],
+    };
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: curvesA, easing: 'linear' },
+      { time: 4, toneCurves: curvesB, easing: 'linear' },
+    ];
+    const result = getToneCurvesAtTime(kfs, 2.0);
+    expect(result).not.toBeNull();
+    // R channel at input=1: 0.5 + (1.0 - 0.5) * 0.5 = 0.75
+    expect(result!.rLUT[255]).toBeCloseTo(0.75, 1);
+    // RGB channel should remain linear (both keyframes have linear RGB)
+    expect(result!.rgbLUT[255]).toBeCloseTo(1.0, 1);
+  });
+});
+
+describe('getToneCurvesAtTime — トーンカーブKFのみのクリップ', () => {
+  // Bug fix #1: トーンカーブKFだけが有効なクリップで renderFrame まで到達しない問題の検証
+  // hasActiveToneCurveKeyframes が true を返す場合、getToneCurvesAtTime は有効な LUT を返す必要がある
+  it('should return valid LUTs for tone-curve-only keyframes (no effect keyframes)', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: makeToneCurves(brightCurve), easing: 'linear' },
+      { time: 4, toneCurves: makeToneCurves(darkCurve), easing: 'linear' },
+    ];
+    expect(hasActiveToneCurveKeyframes(kfs)).toBe(true);
+    const result = getToneCurvesAtTime(kfs, 2.0);
+    expect(result).not.toBeNull();
+    expect(result!.rgbLUT).toBeInstanceOf(Float32Array);
+    expect(result!.rgbLUT.length).toBe(256);
+    expect(result!.rLUT.length).toBe(256);
+    expect(result!.gLUT.length).toBe(256);
+    expect(result!.bLUT.length).toBe(256);
+  });
+
+  it('should return exact keyframe LUT when time matches keyframe exactly', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: makeToneCurves(brightCurve), easing: 'linear' },
+      { time: 4, toneCurves: makeToneCurves(darkCurve), easing: 'linear' },
+    ];
+    // time=0 のキーフレームの値を返す
+    const result = getToneCurvesAtTime(kfs, 0);
+    expect(result).not.toBeNull();
+    expect(result!.rgb).toEqual(brightCurve);
+    // time=4 のキーフレームの値を返す
+    const result2 = getToneCurvesAtTime(kfs, 4);
+    expect(result2).not.toBeNull();
+    expect(result2!.rgb).toEqual(darkCurve);
+  });
+});
+
+describe('hasActiveToneCurveKeyframes', () => {
+  it('should return false for undefined', () => {
+    expect(hasActiveToneCurveKeyframes(undefined)).toBe(false);
+  });
+
+  it('should return false for empty array', () => {
+    expect(hasActiveToneCurveKeyframes([])).toBe(false);
+  });
+
+  it('should return false for single keyframe', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: DEFAULT_TONE_CURVES, easing: 'linear' },
+    ];
+    expect(hasActiveToneCurveKeyframes(kfs)).toBe(false);
+  });
+
+  it('should return true for 2+ keyframes', () => {
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: DEFAULT_TONE_CURVES, easing: 'linear' },
+      { time: 4, toneCurves: DEFAULT_TONE_CURVES, easing: 'linear' },
+    ];
+    expect(hasActiveToneCurveKeyframes(kfs)).toBe(true);
+  });
+});

--- a/src/test/toneCurveKeyframes.test.ts
+++ b/src/test/toneCurveKeyframes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   interpolateToneCurveLUTs,
   getToneCurvesAtTime,
+  getEditableToneCurvesAtTime,
   hasActiveToneCurveKeyframes,
 } from '../utils/toneCurveKeyframes';
 import type { ToneCurves, ToneCurveKeyframe, CurvePoint } from '../store/timeline/types';
@@ -176,6 +177,39 @@ describe('getToneCurvesAtTime — トーンカーブKFのみのクリップ', ()
     const result2 = getToneCurvesAtTime(kfs, 4);
     expect(result2).not.toBeNull();
     expect(result2!.rgb).toEqual(darkCurve);
+  });
+});
+
+describe('getEditableToneCurvesAtTime', () => {
+  it('should return base tone curves when there are no tone-curve keyframes', () => {
+    const baseToneCurves = makeToneCurves(linearCurve);
+    expect(getEditableToneCurvesAtTime(undefined, baseToneCurves, 2.0)).toBe(baseToneCurves);
+  });
+
+  it('should return exact keyframe tone curves when time matches a keyframe', () => {
+    const baseToneCurves = makeToneCurves(linearCurve);
+    const keyframeToneCurves = makeToneCurves(brightCurve);
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 2.0, toneCurves: keyframeToneCurves, easing: 'linear' },
+    ];
+    expect(getEditableToneCurvesAtTime(kfs, baseToneCurves, 2.0)).toBe(keyframeToneCurves);
+  });
+
+  it('should prefer keyframe-derived curves over base tone curves inside an active keyframe range', () => {
+    const baseToneCurves = makeToneCurves(linearCurve);
+    const curvesA = makeToneCurves(brightCurve);
+    const curvesB = makeToneCurves(darkCurve);
+    const kfs: ToneCurveKeyframe[] = [
+      { time: 0, toneCurves: curvesA, easing: 'linear' },
+      { time: 4, toneCurves: curvesB, easing: 'linear' },
+    ];
+
+    const editable = getEditableToneCurvesAtTime(kfs, baseToneCurves, 2.0);
+
+    expect(editable).not.toBe(baseToneCurves);
+    expect(editable.rgb).toHaveLength(5);
+    expect(editable.rgb[0].y).toBeCloseTo(0.1, 1);
+    expect(editable.rgb[editable.rgb.length - 1].y).toBeCloseTo(0.9, 1);
   });
 });
 

--- a/src/utils/toneCurveKeyframes.ts
+++ b/src/utils/toneCurveKeyframes.ts
@@ -1,5 +1,33 @@
-import type { ToneCurves, ToneCurveKeyframe, EasingType } from '../store/timeline/types';
+import type { ToneCurves, ToneCurveKeyframe, CurvePoint, EasingType } from '../store/timeline/types';
 import { buildCurveLUT } from './curveSpline';
+
+/** ToneCurves → LUT キャッシュ（同じ制御点配列参照なら再計算しない） */
+interface CachedChannelLUTs {
+  rgbLUT: Float32Array;
+  rLUT: Float32Array;
+  gLUT: Float32Array;
+  bLUT: Float32Array;
+}
+
+const _lutCache = new WeakMap<CurvePoint[], Float32Array>();
+
+function getCachedLUT(points: CurvePoint[]): Float32Array {
+  let lut = _lutCache.get(points);
+  if (!lut) {
+    lut = buildCurveLUT(points);
+    _lutCache.set(points, lut);
+  }
+  return lut;
+}
+
+function buildCachedChannelLUTs(tc: ToneCurves): CachedChannelLUTs {
+  return {
+    rgbLUT: getCachedLUT(tc.rgb),
+    rLUT: getCachedLUT(tc.r),
+    gLUT: getCachedLUT(tc.g),
+    bLUT: getCachedLUT(tc.b),
+  };
+}
 
 /** 補間結果: 各チャンネルの LUT を直接保持 */
 export interface InterpolatedToneCurves {
@@ -55,25 +83,13 @@ export function getToneCurvesAtTime(
   // 範囲外: 最初のキーフレーム以前
   if (time <= keyframes[0].time) {
     const tc = keyframes[0].toneCurves;
-    return {
-      ...tc,
-      rgbLUT: buildCurveLUT(tc.rgb),
-      rLUT: buildCurveLUT(tc.r),
-      gLUT: buildCurveLUT(tc.g),
-      bLUT: buildCurveLUT(tc.b),
-    };
+    return { ...tc, ...buildCachedChannelLUTs(tc) };
   }
 
   // 範囲外: 最後のキーフレーム以降
   if (time >= keyframes[keyframes.length - 1].time) {
     const tc = keyframes[keyframes.length - 1].toneCurves;
-    return {
-      ...tc,
-      rgbLUT: buildCurveLUT(tc.rgb),
-      rLUT: buildCurveLUT(tc.r),
-      gLUT: buildCurveLUT(tc.g),
-      bLUT: buildCurveLUT(tc.b),
-    };
+    return { ...tc, ...buildCachedChannelLUTs(tc) };
   }
 
   // 区間を特定
@@ -90,33 +106,27 @@ export function getToneCurvesAtTime(
   const range = next.time - prev.time;
   if (range === 0) {
     const tc = prev.toneCurves;
-    return {
-      ...tc,
-      rgbLUT: buildCurveLUT(tc.rgb),
-      rLUT: buildCurveLUT(tc.r),
-      gLUT: buildCurveLUT(tc.g),
-      bLUT: buildCurveLUT(tc.b),
-    };
+    return { ...tc, ...buildCachedChannelLUTs(tc) };
   }
 
   const rawT = (time - prev.time) / range;
   const t = applyEasing(rawT, prev.easing);
 
-  // 各チャンネルの LUT を生成して補間
-  const prevTC = prev.toneCurves;
-  const nextTC = next.toneCurves;
+  // キャッシュ済み LUT を取得して補間
+  const prevLUTs = buildCachedChannelLUTs(prev.toneCurves);
+  const nextLUTs = buildCachedChannelLUTs(next.toneCurves);
 
-  const rgbLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.rgb), buildCurveLUT(nextTC.rgb), t);
-  const rLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.r), buildCurveLUT(nextTC.r), t);
-  const gLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.g), buildCurveLUT(nextTC.g), t);
-  const bLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.b), buildCurveLUT(nextTC.b), t);
+  const rgbLUT = interpolateToneCurveLUTs(prevLUTs.rgbLUT, nextLUTs.rgbLUT, t);
+  const rLUT = interpolateToneCurveLUTs(prevLUTs.rLUT, nextLUTs.rLUT, t);
+  const gLUT = interpolateToneCurveLUTs(prevLUTs.gLUT, nextLUTs.gLUT, t);
+  const bLUT = interpolateToneCurveLUTs(prevLUTs.bLUT, nextLUTs.bLUT, t);
 
   // 補間結果の制御点は prev のものを保持（UI 表示用）
   return {
-    rgb: prevTC.rgb,
-    r: prevTC.r,
-    g: prevTC.g,
-    b: prevTC.b,
+    rgb: prev.toneCurves.rgb,
+    r: prev.toneCurves.r,
+    g: prev.toneCurves.g,
+    b: prev.toneCurves.b,
     rgbLUT,
     rLUT,
     gLUT,

--- a/src/utils/toneCurveKeyframes.ts
+++ b/src/utils/toneCurveKeyframes.ts
@@ -1,0 +1,134 @@
+import type { ToneCurves, ToneCurveKeyframe, EasingType } from '../store/timeline/types';
+import { buildCurveLUT } from './curveSpline';
+
+/** 補間結果: 各チャンネルの LUT を直接保持 */
+export interface InterpolatedToneCurves {
+  rgb: ToneCurves['rgb'];
+  r: ToneCurves['r'];
+  g: ToneCurves['g'];
+  b: ToneCurves['b'];
+  rgbLUT: Float32Array;
+  rLUT: Float32Array;
+  gLUT: Float32Array;
+  bLUT: Float32Array;
+}
+
+function applyEasing(t: number, easing: EasingType): number {
+  switch (easing) {
+    case 'easeIn':    return t * t;
+    case 'easeOut':   return t * (2 - t);
+    case 'easeInOut': return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+    default:          return t; // linear
+  }
+}
+
+/**
+ * 2つの LUT を線形補間する。
+ * @param lutA 補間元 LUT
+ * @param lutB 補間先 LUT
+ * @param t 補間係数（0〜1）
+ */
+export function interpolateToneCurveLUTs(
+  lutA: Float32Array,
+  lutB: Float32Array,
+  t: number,
+): Float32Array {
+  const size = lutA.length;
+  const result = new Float32Array(size);
+  for (let i = 0; i < size; i++) {
+    result[i] = lutA[i] + (lutB[i] - lutA[i]) * t;
+  }
+  return result;
+}
+
+/**
+ * トーンカーブキーフレーム列から指定時刻の補間済みトーンカーブを返す。
+ * キーフレームが 0〜1 個の場合は null（補間不要）。
+ * 2個以上の場合は LUT ベースで補間した結果を返す。
+ */
+export function getToneCurvesAtTime(
+  keyframes: ToneCurveKeyframe[],
+  time: number,
+): InterpolatedToneCurves | null {
+  if (keyframes.length < 2) return null;
+
+  // 範囲外: 最初のキーフレーム以前
+  if (time <= keyframes[0].time) {
+    const tc = keyframes[0].toneCurves;
+    return {
+      ...tc,
+      rgbLUT: buildCurveLUT(tc.rgb),
+      rLUT: buildCurveLUT(tc.r),
+      gLUT: buildCurveLUT(tc.g),
+      bLUT: buildCurveLUT(tc.b),
+    };
+  }
+
+  // 範囲外: 最後のキーフレーム以降
+  if (time >= keyframes[keyframes.length - 1].time) {
+    const tc = keyframes[keyframes.length - 1].toneCurves;
+    return {
+      ...tc,
+      rgbLUT: buildCurveLUT(tc.rgb),
+      rLUT: buildCurveLUT(tc.r),
+      gLUT: buildCurveLUT(tc.g),
+      bLUT: buildCurveLUT(tc.b),
+    };
+  }
+
+  // 区間を特定
+  let prev = keyframes[0];
+  let next = keyframes[1];
+  for (let i = 0; i < keyframes.length - 1; i++) {
+    if (keyframes[i].time <= time && keyframes[i + 1].time > time) {
+      prev = keyframes[i];
+      next = keyframes[i + 1];
+      break;
+    }
+  }
+
+  const range = next.time - prev.time;
+  if (range === 0) {
+    const tc = prev.toneCurves;
+    return {
+      ...tc,
+      rgbLUT: buildCurveLUT(tc.rgb),
+      rLUT: buildCurveLUT(tc.r),
+      gLUT: buildCurveLUT(tc.g),
+      bLUT: buildCurveLUT(tc.b),
+    };
+  }
+
+  const rawT = (time - prev.time) / range;
+  const t = applyEasing(rawT, prev.easing);
+
+  // 各チャンネルの LUT を生成して補間
+  const prevTC = prev.toneCurves;
+  const nextTC = next.toneCurves;
+
+  const rgbLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.rgb), buildCurveLUT(nextTC.rgb), t);
+  const rLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.r), buildCurveLUT(nextTC.r), t);
+  const gLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.g), buildCurveLUT(nextTC.g), t);
+  const bLUT = interpolateToneCurveLUTs(buildCurveLUT(prevTC.b), buildCurveLUT(nextTC.b), t);
+
+  // 補間結果の制御点は prev のものを保持（UI 表示用）
+  return {
+    rgb: prevTC.rgb,
+    r: prevTC.r,
+    g: prevTC.g,
+    b: prevTC.b,
+    rgbLUT,
+    rLUT,
+    gLUT,
+    bLUT,
+  };
+}
+
+/**
+ * トーンカーブキーフレームがアクティブ（2個以上）かを判定する。
+ */
+export function hasActiveToneCurveKeyframes(
+  keyframes: ToneCurveKeyframe[] | undefined,
+): boolean {
+  return !!keyframes && keyframes.length >= 2;
+}

--- a/src/utils/toneCurveKeyframes.ts
+++ b/src/utils/toneCurveKeyframes.ts
@@ -9,6 +9,8 @@ interface CachedChannelLUTs {
   bLUT: Float32Array;
 }
 
+const DISPLAY_POINT_COUNT = 5;
+
 const _lutCache = new WeakMap<CurvePoint[], Float32Array>();
 
 function getCachedLUT(points: CurvePoint[]): Float32Array {
@@ -26,6 +28,31 @@ function buildCachedChannelLUTs(tc: ToneCurves): CachedChannelLUTs {
     rLUT: getCachedLUT(tc.r),
     gLUT: getCachedLUT(tc.g),
     bLUT: getCachedLUT(tc.b),
+  };
+}
+
+function lutIndexAt(x: number, size: number): number {
+  return Math.max(0, Math.min(size - 1, Math.round(x * (size - 1))));
+}
+
+function curvePointsFromLUT(lut: Float32Array, pointCount: number = DISPLAY_POINT_COUNT): CurvePoint[] {
+  const points: CurvePoint[] = [];
+  for (let i = 0; i < pointCount; i++) {
+    const x = i / (pointCount - 1);
+    points.push({
+      x,
+      y: lut[lutIndexAt(x, lut.length)],
+    });
+  }
+  return points;
+}
+
+function toneCurvesFromInterpolatedLUTs(luts: CachedChannelLUTs): ToneCurves {
+  return {
+    rgb: curvePointsFromLUT(luts.rgbLUT),
+    r: curvePointsFromLUT(luts.rLUT),
+    g: curvePointsFromLUT(luts.gLUT),
+    b: curvePointsFromLUT(luts.bLUT),
   };
 }
 
@@ -141,4 +168,35 @@ export function hasActiveToneCurveKeyframes(
   keyframes: ToneCurveKeyframe[] | undefined,
 ): boolean {
   return !!keyframes && keyframes.length >= 2;
+}
+
+/**
+ * エディタ表示用のトーンカーブを返す。
+ * 既存KFがあればその値を優先し、KF区間中は補間結果に紐づく制御点を返す。
+ */
+export function getEditableToneCurvesAtTime(
+  keyframes: ToneCurveKeyframe[] | undefined,
+  baseToneCurves: ToneCurves,
+  time: number,
+): ToneCurves {
+  if (!keyframes || keyframes.length === 0) {
+    return baseToneCurves;
+  }
+
+  const exact = keyframes.find((kf) => Math.abs(kf.time - time) <= 0.001);
+  if (exact) {
+    return exact.toneCurves;
+  }
+
+  const interpolated = getToneCurvesAtTime(keyframes, time);
+  if (interpolated) {
+    return toneCurvesFromInterpolatedLUTs({
+      rgbLUT: interpolated.rgbLUT,
+      rLUT: interpolated.rLUT,
+      gLUT: interpolated.gLUT,
+      bLUT: interpolated.bLUT,
+    });
+  }
+
+  return baseToneCurves;
 }


### PR DESCRIPTION
## Summary
- トーンカーブを時間軸でアニメーションさせるキーフレーム機能を実装
- LUTベース補間により異なる制御点数のカーブ間でもスムーズに補間
- レビューで発見された3件のバグ（早期return / KF値編集 / リセット漏れ）を修正済み

## 変更内容
- `ToneCurveKeyframe` 型・`Clip` フィールド追加
- `toneCurveKeyframes.ts`: LUT生成・補間・判定ロジック
- `clipSlice.ts`: add / remove / updateEasing ストア操作（undo/redo対応）
- `canvasEffects.ts`: `PrecomputedLUTs` パラメータ追加
- `useCanvasRenderer.ts`: トーンカーブKF補間→WebGL描画統合、早期return修正
- `EffectsPanel.tsx`: KF追加/削除UI、KF値の直接編集、リセット対応
- i18n（en/ja）翻訳追加
- テスト16件追加（補間ロジック + ストア操作）

## 手打鍵チェックリスト
- [x] クリップを選択し、トーンカーブセクションを開く
- [x] 再生ヘッドを0秒に移動し「キーフレーム追加」ボタンを押す → KFが追加される
- [x] 再生ヘッドを4秒に移動し「キーフレーム追加」ボタンを押す → 2個目のKFが追加される
- [x] 4秒のKFでカーブを編集 → プレビューに反映される
- [x] 再生ヘッドを2秒に移動 → 補間されたトーンカーブがプレビューに表示される
- [x] 0秒に戻る → 0秒のKF値がCurveEditorに表示される（ベースカーブではない）
- [x] 通常のエフェクトKFなし・トーンカーブKFのみの状態でプレビューに反映される
- [x] 「リセット」ボタンを押す → トーンカーブKFも含めすべてリセットされる
- [x] KFが存在する時刻で「キーフレーム削除」ボタンを押す → KFが削除される

Closes #160