### PR TITLE
Fix preview overlay scaling for resize

### DIFF
--- a/src/components/VideoPreview/VideoPreview.tsx
+++ b/src/components/VideoPreview/VideoPreview.tsx
@@ -11,6 +11,8 @@ import { useAudioTrackPlayback } from './useAudioTrackPlayback';
 import { useCanvasRenderer } from './useCanvasRenderer';
 import { useFrameCapture } from './useFrameCapture';
 import { audioEngine } from '../../audio/AudioEngine';
+import { scaleOverlayFontSize, scaleOverlayPixels } from '../../utils/overlayScale';
+import { calculateContainedRect } from '../../utils/videoDisplayRect';
 
 const VIDEO_AUDIO_ID = '__video_main__';
 
@@ -31,6 +33,7 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
     volume,
     videoUrls,
     prerenderedFrames,
+    previewContainerHeight,
     setIsPlaying,
     setCurrentTime: setVideoPreviewCurrentTime,
     setDuration,
@@ -38,14 +41,17 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
   } = useVideoPreviewStore();
 
   const tracks = useTimelineStore((s) => s.tracks);
+  const [previewContainerWidth, setPreviewContainerWidth] = useState(0);
 
   // プレビューコンテナの高さを監視
   const previewContainerRef = useRef<HTMLDivElement>(null);
+  const overlayFrameRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = previewContainerRef.current;
     if (!el) return;
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
+        setPreviewContainerWidth(entry.contentRect.width);
         setPreviewContainerHeight(entry.contentRect.height);
       }
     });
@@ -168,13 +174,8 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
   }, [activeVideoRef, currentVideoUrl, needsCanvas, renderCanvasFrame, videoRef]);
 
   useEffect(() => {
-    const video = activeVideoRef.current ?? videoRef.current;
-    if (!currentVideoUrl || !video) {
-      setIsVideoReady(false);
-      return;
-    }
-    setIsVideoReady(video.readyState >= 2 && video.currentSrc === currentVideoUrl);
-  }, [activeVideoRef, currentVideoUrl, videoRef]);
+    setIsVideoReady(false);
+  }, [currentVideoUrl, currentClipId]);
 
   // 停止中にタイムライン上で時刻を変更した場合も canvas preview を再描画する
   useEffect(() => {
@@ -203,7 +204,27 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
   }, []);
 
   const { textOverlays, textCurrentTime, calcTextOpacity, calcTextTranslateY } = useTextOverlays();
-  const { timecodeDisplay, isDragging, handlePointerDown, handlePointerMove, handlePointerUp } = useTimecodeOverlay(previewContainerRef);
+  const { timecodeDisplay, isDragging, handlePointerDown, handlePointerMove, handlePointerUp } = useTimecodeOverlay(overlayFrameRef);
+
+  const activeOverlayVideo = activeVideoRef.current ?? videoRef.current ?? preloadVideoRef.current;
+  const hasMeasuredVideo =
+    (activeOverlayVideo?.videoWidth ?? 0) > 0
+    && (activeOverlayVideo?.videoHeight ?? 0) > 0;
+  const overlayFrameRect = hasMeasuredVideo
+    ? calculateContainedRect(
+      { width: previewContainerWidth, height: previewContainerHeight },
+      {
+        width: activeOverlayVideo?.videoWidth ?? 0,
+        height: activeOverlayVideo?.videoHeight ?? 0,
+      },
+    )
+    : { left: 0, top: 0, width: 0, height: 0 };
+  const hasRenderablePreview = hasCurrentClip && (isVideoReady || Boolean(currentPrerenderedFrame));
+  const hasVisibleVideoFrame =
+    hasRenderablePreview
+    && hasMeasuredVideo
+    && overlayFrameRect.width > 0
+    && overlayFrameRect.height > 0;
 
   const {
     transitionVideoRef,
@@ -342,7 +363,12 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   const handleVideoLoadedData = useCallback((e: React.SyntheticEvent<HTMLVideoElement>) => {
     const activeVideo = activeVideoRef.current ?? videoRef.current;
-    if (activeVideo === e.currentTarget) {
+    if (
+      activeVideo === e.currentTarget
+      && e.currentTarget.readyState >= 2
+      && e.currentTarget.videoWidth > 0
+      && !e.currentTarget.seeking
+    ) {
       setIsVideoReady(true);
     }
   }, [activeVideoRef, videoRef]);
@@ -356,7 +382,11 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   const handleVideoSeeked = useCallback((e: React.SyntheticEvent<HTMLVideoElement>) => {
     const activeVideo = activeVideoRef.current ?? videoRef.current;
-    if (activeVideo === e.currentTarget) {
+    if (
+      activeVideo === e.currentTarget
+      && e.currentTarget.readyState >= 2
+      && e.currentTarget.videoWidth > 0
+    ) {
       setIsVideoReady(true);
     }
   }, [activeVideoRef, videoRef]);
@@ -417,6 +447,7 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
             height: '100%',
             backgroundColor: '#000',
             borderRadius: '4px',
+            objectFit: 'contain',
             visibility:
               hasCurrentClip && !needsCanvas && activeVideoSlot === 'primary'
                 ? 'visible'
@@ -523,62 +554,81 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
             {!Object.keys(videoUrls).length && t('fileOperations.noFile')}
           </div>
         )}
-        {/* テキストオーバーレイ */}
-        {textOverlays.map((clip) => {
-          const tp = clip.textProperties!;
-          const elapsed = textCurrentTime - clip.startTime;
-          const opacity = calcTextOpacity(tp, elapsed, clip.duration);
-          const translateY = calcTextTranslateY(tp, elapsed, clip.duration);
-          return (
-            <div
-              key={clip.id}
-              style={{
-                position: 'absolute',
-                left: `${tp.positionX}%`,
-                top: `${tp.positionY}%`,
-                transform: `translate(-50%, -50%) translateY(${translateY}px)`,
-                fontSize: `${tp.fontSize}px`,
-                fontFamily: tp.fontFamily,
-                fontWeight: tp.bold ? 'bold' : 'normal',
-                fontStyle: tp.italic ? 'italic' : 'normal',
-                textAlign: tp.textAlign,
-                color: tp.fontColor,
-                opacity,
-                backgroundColor: tp.backgroundColor === 'transparent' ? undefined : tp.backgroundColor,
-                padding: tp.backgroundColor !== 'transparent' ? '4px 8px' : undefined,
-                borderRadius: tp.backgroundColor !== 'transparent' ? '4px' : undefined,
-                textShadow: '1px 1px 3px rgba(0,0,0,0.8), -1px -1px 3px rgba(0,0,0,0.8)',
-                whiteSpace: 'pre-wrap',
-                pointerEvents: 'none',
-                zIndex: 10,
-              }}
-            >
-              {tp.text}
-            </div>
-          );
-        })}
-        {/* タイムコードオーバーレイ（ドラッグ移動可能） */}
-        {timecodeDisplay && (
+        {hasVisibleVideoFrame && (
           <div
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
+            ref={overlayFrameRef}
             style={{
               position: 'absolute',
-              left: `${timecodeDisplay.overlay.positionX}%`,
-              top: `${timecodeDisplay.overlay.positionY}%`,
-              transform: 'translate(-50%, -50%)',
-              fontSize: `${timecodeDisplay.overlay.fontSize}px`,
-              fontFamily: 'monospace',
-              color: timecodeDisplay.overlay.fontColor,
-              textShadow: '1px 1px 3px rgba(0,0,0,0.8), -1px -1px 3px rgba(0,0,0,0.8)',
-              cursor: isDragging ? 'grabbing' : 'grab',
-              userSelect: 'none',
-              zIndex: 11,
-              whiteSpace: 'nowrap',
+              left: `${overlayFrameRect.left}px`,
+              top: `${overlayFrameRect.top}px`,
+              width: `${overlayFrameRect.width}px`,
+              height: `${overlayFrameRect.height}px`,
+              pointerEvents: 'none',
             }}
           >
-            {timecodeDisplay.text}
+          {/* テキストオーバーレイ */}
+          {textOverlays.map((clip) => {
+            const tp = clip.textProperties!;
+            const elapsed = textCurrentTime - clip.startTime;
+            const opacity = calcTextOpacity(tp, elapsed, clip.duration);
+            const translateY = calcTextTranslateY(tp, elapsed, clip.duration);
+            const scaledFontSize = scaleOverlayFontSize(tp.fontSize, overlayFrameRect.height);
+            const scaledTranslateY = scaleOverlayPixels(translateY, overlayFrameRect.height);
+            const scaledPaddingY = scaleOverlayPixels(4, overlayFrameRect.height);
+            const scaledPaddingX = scaleOverlayPixels(8, overlayFrameRect.height);
+            return (
+              <div
+                key={clip.id}
+                style={{
+                  position: 'absolute',
+                  left: `${tp.positionX}%`,
+                  top: `${tp.positionY}%`,
+                  transform: `translate(-50%, -50%) translateY(${scaledTranslateY}px)`,
+                  fontSize: `${scaledFontSize}px`,
+                  fontFamily: tp.fontFamily,
+                  fontWeight: tp.bold ? 'bold' : 'normal',
+                  fontStyle: tp.italic ? 'italic' : 'normal',
+                  textAlign: tp.textAlign,
+                  color: tp.fontColor,
+                  opacity,
+                  backgroundColor: tp.backgroundColor === 'transparent' ? undefined : tp.backgroundColor,
+                  padding: tp.backgroundColor !== 'transparent' ? `${scaledPaddingY}px ${scaledPaddingX}px` : undefined,
+                  borderRadius: tp.backgroundColor !== 'transparent' ? `${scaleOverlayPixels(4, overlayFrameRect.height)}px` : undefined,
+                  textShadow: '1px 1px 3px rgba(0,0,0,0.8), -1px -1px 3px rgba(0,0,0,0.8)',
+                  whiteSpace: 'pre-wrap',
+                  pointerEvents: 'none',
+                  zIndex: 10,
+                }}
+              >
+                {tp.text}
+              </div>
+            );
+          })}
+          {/* タイムコードオーバーレイ（ドラッグ移動可能） */}
+          {timecodeDisplay && (
+            <div
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              style={{
+                position: 'absolute',
+                left: `${timecodeDisplay.overlay.positionX}%`,
+                top: `${timecodeDisplay.overlay.positionY}%`,
+                transform: 'translate(-50%, -50%)',
+                fontSize: `${scaleOverlayFontSize(timecodeDisplay.overlay.fontSize, overlayFrameRect.height)}px`,
+                fontFamily: 'monospace',
+                color: timecodeDisplay.overlay.fontColor,
+                textShadow: '1px 1px 3px rgba(0,0,0,0.8), -1px -1px 3px rgba(0,0,0,0.8)',
+                cursor: isDragging ? 'grabbing' : 'grab',
+                userSelect: 'none',
+                zIndex: 11,
+                whiteSpace: 'nowrap',
+                pointerEvents: 'auto',
+              }}
+            >
+              {timecodeDisplay.text}
+            </div>
+          )}
           </div>
         )}
       </div>

--- a/src/components/VideoPreview/useTimecodeOverlay.ts
+++ b/src/components/VideoPreview/useTimecodeOverlay.ts
@@ -20,7 +20,7 @@ interface UseTimecodeOverlayReturn {
 }
 
 export const useTimecodeOverlay = (
-  containerRef: React.RefObject<HTMLDivElement | null>,
+  overlayFrameRef: React.RefObject<HTMLDivElement | null>,
 ): UseTimecodeOverlayReturn => {
   const tracks = useTimelineStore((s) => s.tracks);
   const [timecodeDisplay, setTimecodeDisplay] = useState<TimecodeDisplay | null>(null);
@@ -67,13 +67,13 @@ export const useTimecodeOverlay = (
   }, [tracks, findVideoClipAtTime]);
 
   const calcPosition = useCallback((e: React.PointerEvent): { x: number; y: number } | null => {
-    const container = containerRef.current;
-    if (!container) return null;
-    const rect = container.getBoundingClientRect();
+    const overlayFrame = overlayFrameRef.current;
+    if (!overlayFrame) return null;
+    const rect = overlayFrame.getBoundingClientRect();
     const x = Math.max(0, Math.min(100, ((e.clientX - rect.left) / rect.width) * 100));
     const y = Math.max(0, Math.min(100, ((e.clientY - rect.top) / rect.height) * 100));
     return { x, y };
-  }, [containerRef]);
+  }, [overlayFrameRef]);
 
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
     e.preventDefault();

--- a/src/components/VideoPreview/useVideoSwitching.ts
+++ b/src/components/VideoPreview/useVideoSwitching.ts
@@ -275,39 +275,29 @@ export const useVideoSwitching = ({
     const clipId = currentClip?.id ?? null;
     const needsInitialFrameNudge = Math.abs(targetSourceTime) < 0.001;
     let nudgedAwayFromStart = false;
-    video.src = currentVideoUrl;
-    video.load();
 
-    video.addEventListener(
-      'loadedmetadata',
-      () => {
-        if (!videoRef.current) return;
-        if (needsInitialFrameNudge && videoRef.current.duration > 0.001) {
-          videoRef.current.currentTime = Math.min(videoRef.current.duration, 0.001);
-          nudgedAwayFromStart = true;
-        } else if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.001) {
-          videoRef.current.currentTime = targetSourceTime;
-        }
-        setDuration(videoRef.current.duration);
-      },
-      { once: true },
-    );
+    const handleLoadedMetadata = () => {
+      if (!videoRef.current) return;
+      if (needsInitialFrameNudge && videoRef.current.duration > 0.001) {
+        videoRef.current.currentTime = Math.min(videoRef.current.duration, 0.001);
+        nudgedAwayFromStart = true;
+      } else if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.001) {
+        videoRef.current.currentTime = targetSourceTime;
+      }
+      setDuration(videoRef.current.duration);
+    };
 
-    video.addEventListener(
-      'loadeddata',
-      () => {
-        if (!videoRef.current) return;
-        if (videoRef.current.seeking) return;
-        if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.001) {
-          videoRef.current.currentTime = targetSourceTime;
-          return;
-        }
-        if (clipId) {
-          captureVideoFrame(videoRef.current, clipId);
-        }
-      },
-      { once: true },
-    );
+    const handleLoadedData = () => {
+      if (!videoRef.current) return;
+      if (videoRef.current.seeking) return;
+      if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.001) {
+        videoRef.current.currentTime = targetSourceTime;
+        return;
+      }
+      if (clipId) {
+        captureVideoFrame(videoRef.current, clipId);
+      }
+    };
 
     const handleSeeked = () => {
       if (!videoRef.current) return;
@@ -323,7 +313,18 @@ export const useVideoSwitching = ({
       }
       videoRef.current.removeEventListener('seeked', handleSeeked);
     };
+
+    video.src = currentVideoUrl;
+    video.load();
+    video.addEventListener('loadedmetadata', handleLoadedMetadata, { once: true });
+    video.addEventListener('loadeddata', handleLoadedData, { once: true });
     video.addEventListener('seeked', handleSeeked);
+
+    return () => {
+      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      video.removeEventListener('loadeddata', handleLoadedData);
+      video.removeEventListener('seeked', handleSeeked);
+    };
   }, [videoRef, currentClip?.id, currentTimeRef, currentVideoUrl, timelineTimeToSourceTime, setDuration, captureVideoFrame]);
 
   return {

--- a/src/components/VideoPreview/useVideoSwitching.ts
+++ b/src/components/VideoPreview/useVideoSwitching.ts
@@ -100,6 +100,24 @@ export const useVideoSwitching = ({
 
   const { setDuration, setPrerenderedFrame, clearPrerenderedFrame } = useVideoPreviewStore();
 
+  const captureVideoFrame = useCallback(
+    (video: HTMLVideoElement, clipId: string) => {
+      if (!video.videoWidth || !video.videoHeight) return;
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      try {
+        setPrerenderedFrame(clipId, canvas.toDataURL('image/png'));
+      } catch {
+        // CORS などで data URL 化できない場合はプリレンダ保存のみスキップする
+      }
+    },
+    [setPrerenderedFrame],
+  );
+
   useEffect(() => {
     if (videoRef.current && !activeVideoRef.current) {
       activeVideoRef.current = videoRef.current;
@@ -200,18 +218,7 @@ export const useVideoSwitching = ({
     const clipId = nextClip.id;
     const preloadVideo = preloadTarget;
     const capturePrerenderFrame = () => {
-      if (!preloadVideo.videoWidth || !preloadVideo.videoHeight) return;
-      const canvas = document.createElement('canvas');
-      canvas.width = preloadVideo.videoWidth;
-      canvas.height = preloadVideo.videoHeight;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-      ctx.drawImage(preloadVideo, 0, 0, canvas.width, canvas.height);
-      try {
-        setPrerenderedFrame(clipId, canvas.toDataURL('image/png'));
-      } catch {
-        // CORS などで data URL 化できない場合はプリレンダ保存のみスキップする
-      }
+      captureVideoFrame(preloadVideo, clipId);
     };
 
     const handleLoadedMetadata = () => {
@@ -241,11 +248,11 @@ export const useVideoSwitching = ({
       preloadVideo.removeEventListener('loadeddata', handleLoadedData);
     };
   }, [
+    captureVideoFrame,
     clearPrerenderedFrame,
     currentClip,
     findNextClipAfter,
     videoRef,
-    setPrerenderedFrame,
     videoUrls,
   ]);
 
@@ -265,6 +272,9 @@ export const useVideoSwitching = ({
 
     const targetSourceTime = timelineTimeToSourceTime(currentTimeRef.current);
     const video = videoRef.current;
+    const clipId = currentClip?.id ?? null;
+    const needsInitialFrameNudge = Math.abs(targetSourceTime) < 0.001;
+    let nudgedAwayFromStart = false;
     video.src = currentVideoUrl;
     video.load();
 
@@ -272,12 +282,49 @@ export const useVideoSwitching = ({
       'loadedmetadata',
       () => {
         if (!videoRef.current) return;
-        videoRef.current.currentTime = targetSourceTime;
+        if (needsInitialFrameNudge && videoRef.current.duration > 0.001) {
+          videoRef.current.currentTime = Math.min(videoRef.current.duration, 0.001);
+          nudgedAwayFromStart = true;
+        } else if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.001) {
+          videoRef.current.currentTime = targetSourceTime;
+        }
         setDuration(videoRef.current.duration);
       },
       { once: true },
     );
-  }, [videoRef, currentTimeRef, currentVideoUrl, timelineTimeToSourceTime, setDuration]);
+
+    video.addEventListener(
+      'loadeddata',
+      () => {
+        if (!videoRef.current) return;
+        if (videoRef.current.seeking) return;
+        if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.001) {
+          videoRef.current.currentTime = targetSourceTime;
+          return;
+        }
+        if (clipId) {
+          captureVideoFrame(videoRef.current, clipId);
+        }
+      },
+      { once: true },
+    );
+
+    const handleSeeked = () => {
+      if (!videoRef.current) return;
+      if (nudgedAwayFromStart) {
+        nudgedAwayFromStart = false;
+        if (Math.abs(videoRef.current.currentTime - targetSourceTime) > 0.0001) {
+          videoRef.current.currentTime = targetSourceTime;
+          return;
+        }
+      }
+      if (clipId) {
+        captureVideoFrame(videoRef.current, clipId);
+      }
+      videoRef.current.removeEventListener('seeked', handleSeeked);
+    };
+    video.addEventListener('seeked', handleSeeked);
+  }, [videoRef, currentClip?.id, currentTimeRef, currentVideoUrl, timelineTimeToSourceTime, setDuration, captureVideoFrame]);
 
   return {
     preloadVideoRef,

--- a/src/test/overlayScale.test.ts
+++ b/src/test/overlayScale.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getOverlayScale, scaleOverlayFontSize, scaleOverlayPixels } from '../utils/overlayScale';
+
+describe('overlayScale', () => {
+  it('returns 1 when preview height is invalid', () => {
+    expect(getOverlayScale(0)).toBe(1);
+    expect(getOverlayScale(Number.NaN)).toBe(1);
+  });
+
+  it('scales relative to the base preview height', () => {
+    expect(getOverlayScale(360)).toBe(1);
+    expect(getOverlayScale(720)).toBe(2);
+    expect(getOverlayScale(180)).toBe(0.5);
+  });
+
+  it('scales font size and keeps a minimum readable size', () => {
+    expect(scaleOverlayFontSize(24, 360)).toBe(24);
+    expect(scaleOverlayFontSize(24, 720)).toBe(48);
+    expect(scaleOverlayFontSize(16, 120)).toBe(8);
+  });
+
+  it('scales arbitrary pixel offsets', () => {
+    expect(scaleOverlayPixels(20, 360)).toBe(20);
+    expect(scaleOverlayPixels(20, 720)).toBe(40);
+    expect(scaleOverlayPixels(20, 180)).toBe(10);
+  });
+});

--- a/src/test/videoDisplayRect.test.ts
+++ b/src/test/videoDisplayRect.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { calculateContainedRect } from '../utils/videoDisplayRect';
+
+describe('calculateContainedRect', () => {
+  it('fits landscape media with vertical letterboxing', () => {
+    const rect = calculateContainedRect(
+      { width: 1200, height: 1000 },
+      { width: 1920, height: 1080 },
+    );
+
+    expect(rect.left).toBe(0);
+    expect(rect.width).toBe(1200);
+    expect(rect.height).toBeCloseTo(675);
+    expect(rect.top).toBeCloseTo(162.5);
+  });
+
+  it('fits portrait media with horizontal pillarboxing', () => {
+    const rect = calculateContainedRect(
+      { width: 1200, height: 800 },
+      { width: 1080, height: 1920 },
+    );
+
+    expect(rect.top).toBe(0);
+    expect(rect.height).toBe(800);
+    expect(rect.width).toBeCloseTo(450);
+    expect(rect.left).toBeCloseTo(375);
+  });
+
+  it('returns the full container when aspect ratios match', () => {
+    const rect = calculateContainedRect(
+      { width: 1280, height: 720 },
+      { width: 1920, height: 1080 },
+    );
+
+    expect(rect).toEqual({ left: 0, top: 0, width: 1280, height: 720 });
+  });
+});

--- a/src/test/videoDisplayRect.test.ts
+++ b/src/test/videoDisplayRect.test.ts
@@ -34,4 +34,13 @@ describe('calculateContainedRect', () => {
 
     expect(rect).toEqual({ left: 0, top: 0, width: 1280, height: 720 });
   });
+
+  it('clamps invalid container dimensions to zero in the fallback path', () => {
+    expect(
+      calculateContainedRect(
+        { width: Number.POSITIVE_INFINITY, height: -10 },
+        { width: 1920, height: 1080 },
+      ),
+    ).toEqual({ left: 0, top: 0, width: 0, height: 0 });
+  });
 });

--- a/src/utils/overlayScale.ts
+++ b/src/utils/overlayScale.ts
@@ -1,0 +1,15 @@
+const PREVIEW_BASE_HEIGHT = 360;
+const MIN_FONT_SIZE_PX = 8;
+
+export function getOverlayScale(previewHeight: number): number {
+  if (!Number.isFinite(previewHeight) || previewHeight <= 0) return 1;
+  return previewHeight / PREVIEW_BASE_HEIGHT;
+}
+
+export function scaleOverlayFontSize(fontSize: number, previewHeight: number): number {
+  return Math.max(MIN_FONT_SIZE_PX, Math.round(fontSize * getOverlayScale(previewHeight)));
+}
+
+export function scaleOverlayPixels(value: number, previewHeight: number): number {
+  return Math.round(value * getOverlayScale(previewHeight) * 100) / 100;
+}

--- a/src/utils/videoDisplayRect.ts
+++ b/src/utils/videoDisplayRect.ts
@@ -8,6 +8,10 @@ export interface Rect2D extends Size2D {
   top: number;
 }
 
+function normalizeFiniteNonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
 export function calculateContainedRect(container: Size2D, media: Size2D): Rect2D {
   if (
     !Number.isFinite(container.width)
@@ -19,7 +23,12 @@ export function calculateContainedRect(container: Size2D, media: Size2D): Rect2D
     || media.width <= 0
     || media.height <= 0
   ) {
-    return { left: 0, top: 0, width: container.width || 0, height: container.height || 0 };
+    return {
+      left: 0,
+      top: 0,
+      width: normalizeFiniteNonNegative(container.width),
+      height: normalizeFiniteNonNegative(container.height),
+    };
   }
 
   const containerAspect = container.width / container.height;

--- a/src/utils/videoDisplayRect.ts
+++ b/src/utils/videoDisplayRect.ts
@@ -1,0 +1,47 @@
+export interface Size2D {
+  width: number;
+  height: number;
+}
+
+export interface Rect2D extends Size2D {
+  left: number;
+  top: number;
+}
+
+export function calculateContainedRect(container: Size2D, media: Size2D): Rect2D {
+  if (
+    !Number.isFinite(container.width)
+    || !Number.isFinite(container.height)
+    || container.width <= 0
+    || container.height <= 0
+    || !Number.isFinite(media.width)
+    || !Number.isFinite(media.height)
+    || media.width <= 0
+    || media.height <= 0
+  ) {
+    return { left: 0, top: 0, width: container.width || 0, height: container.height || 0 };
+  }
+
+  const containerAspect = container.width / container.height;
+  const mediaAspect = media.width / media.height;
+
+  if (mediaAspect > containerAspect) {
+    const width = container.width;
+    const height = width / mediaAspect;
+    return {
+      left: 0,
+      top: (container.height - height) / 2,
+      width,
+      height,
+    };
+  }
+
+  const height = container.height;
+  const width = height * mediaAspect;
+  return {
+    left: (container.width - width) / 2,
+    top: 0,
+    width,
+    height,
+  };
+}


### PR DESCRIPTION
## Summary
- anchor timecode and text overlays to the actual contained video rect instead of the full preview area
- scale overlay font sizes with the visible video area and keep drag coordinates in the same coordinate space
- ensure the initial paused frame renders reliably at startup, including the 0s case

## Testing
- npm run lint
- npm run test
- npm run build

Closes #193