### PR TITLE
TimelineTransition 型定義とストア追加（Issue #196）

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -147,17 +147,18 @@ function applyProjectToStores(project: ProjectFile): void {
   }
 
   // タイムラインをリセットしてトラックを復元
+  const tracks = project.timeline.tracks.map((track) => ({
+    ...track,
+    clips: track.clips.map((clip) => ({ ...clip })),
+  }));
   useTimelineStore.setState({
-    tracks: project.timeline.tracks.map((track) => ({
-      ...track,
-      clips: track.clips.map((clip) => ({ ...clip })),
-    })),
+    tracks,
     transitions: [],
     selectedClipId: null,
     selectedTrackId: null,
     currentTime: 0,
     isPlaying: false,
-    _history: [{ tracks: project.timeline.tracks, transitions: [] }],
+    _history: [{ tracks, transitions: [] }],
     _historyIndex: 0,
   });
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -152,11 +152,12 @@ function applyProjectToStores(project: ProjectFile): void {
       ...track,
       clips: track.clips.map((clip) => ({ ...clip })),
     })),
+    transitions: [],
     selectedClipId: null,
     selectedTrackId: null,
     currentTime: 0,
     isPlaying: false,
-    _history: [project.timeline.tracks],
+    _history: [{ tracks: project.timeline.tracks, transitions: [] }],
     _historyIndex: 0,
   });
 

--- a/src/store/timeline/historySlice.ts
+++ b/src/store/timeline/historySlice.ts
@@ -1,33 +1,49 @@
 import type { StoreApi } from 'zustand';
 import { logAction } from '../actionLogger';
-import type { TimelineState, Track } from './types';
+import type { TimelineHistoryEntry, TimelineState, TimelineTransition, Track } from './types';
 
 const MAX_HISTORY = 50;
 
-/** Record new tracks into history (call with the NEW tracks state) */
+function cloneHistoryEntry(entry: TimelineHistoryEntry): TimelineHistoryEntry {
+  return JSON.parse(JSON.stringify(entry));
+}
+
+function buildHistoryEntry(tracks: Track[], transitions: TimelineTransition[]): TimelineHistoryEntry {
+  return cloneHistoryEntry({ tracks, transitions });
+}
+
+/** Record new timeline state into history (call with the NEW state) */
 export function withHistory(
-  state: Pick<TimelineState, '_history' | '_historyIndex'>,
+  state: Pick<TimelineState, '_history' | '_historyIndex' | 'transitions'>,
   newTracks: Track[],
-): Pick<TimelineState, 'tracks' | '_history' | '_historyIndex'> {
+  newTransitions: TimelineTransition[] = state.transitions,
+): Pick<TimelineState, 'tracks' | 'transitions' | '_history' | '_historyIndex'> {
   const history = state._history.slice(0, state._historyIndex + 1);
-  history.push(JSON.parse(JSON.stringify(newTracks)));
+  history.push(buildHistoryEntry(newTracks, newTransitions));
   if (history.length > MAX_HISTORY) history.shift();
-  return { tracks: newTracks, _history: history, _historyIndex: history.length - 1 };
+  return {
+    tracks: newTracks,
+    transitions: newTransitions,
+    _history: history,
+    _historyIndex: history.length - 1,
+  };
 }
 
 type Set = StoreApi<TimelineState>['setState'];
 type Get = StoreApi<TimelineState>['getState'];
 
 export const createHistorySlice = (set: Set, get: Get) => ({
-  _history: [[]] as Track[][],
+  _history: [{ tracks: [], transitions: [] }] as TimelineHistoryEntry[],
   _historyIndex: 0,
 
   undo: () => set((state) => {
     if (state._historyIndex <= 0) return state;
     logAction('undo', `index=${state._historyIndex - 1}`);
     const newIndex = state._historyIndex - 1;
+    const entry = cloneHistoryEntry(state._history[newIndex]);
     return {
-      tracks: JSON.parse(JSON.stringify(state._history[newIndex])),
+      tracks: entry.tracks,
+      transitions: entry.transitions,
       _historyIndex: newIndex,
       selectedClipId: null,
       selectedTrackId: null,
@@ -38,8 +54,10 @@ export const createHistorySlice = (set: Set, get: Get) => ({
     if (state._historyIndex >= state._history.length - 1) return state;
     logAction('redo', `index=${state._historyIndex + 1}`);
     const newIndex = state._historyIndex + 1;
+    const entry = cloneHistoryEntry(state._history[newIndex]);
     return {
-      tracks: JSON.parse(JSON.stringify(state._history[newIndex])),
+      tracks: entry.tracks,
+      transitions: entry.transitions,
       _historyIndex: newIndex,
       selectedClipId: null,
       selectedTrackId: null,
@@ -54,7 +72,7 @@ export const createHistorySlice = (set: Set, get: Get) => ({
 
   commitHistory: () => set((state) => {
     const history = state._history.slice(0, state._historyIndex + 1);
-    history.push(JSON.parse(JSON.stringify(state.tracks)));
+    history.push(buildHistoryEntry(state.tracks, state.transitions));
     if (history.length > MAX_HISTORY) history.shift();
     return { _history: history, _historyIndex: history.length - 1 };
   }),

--- a/src/store/timeline/index.ts
+++ b/src/store/timeline/index.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { TimelineState } from './types';
 import { createPlaybackSlice } from './playbackSlice';
 import { createTrackSlice } from './trackSlice';
+import { createTransitionSlice } from './transitionSlice';
 import { createClipSlice } from './clipSlice';
 import { createHistorySlice } from './historySlice';
 import { createClipboardSlice } from './clipboardSlice';
@@ -9,6 +10,7 @@ import { createClipboardSlice } from './clipboardSlice';
 export const useTimelineStore = create<TimelineState>((set, get) => ({
   ...createPlaybackSlice(set),
   ...createTrackSlice(set),
+  ...createTransitionSlice(set, get),
   ...createClipSlice(set),
   ...createHistorySlice(set, get),
   ...createClipboardSlice(set),
@@ -29,8 +31,10 @@ export type {
   TimecodeOverlay,
   TransitionType,
   ClipTransition,
+  TimelineTransition,
   Clip,
   Track,
+  TimelineHistoryEntry,
   TimelineState,
 } from './types';
 

--- a/src/store/timeline/transitionSlice.ts
+++ b/src/store/timeline/transitionSlice.ts
@@ -44,7 +44,10 @@ export const createTransitionSlice = (set: Set, get: Get) => ({
     return withHistory(state, state.tracks, newTransitions);
   }),
 
-  updateTransition: (transitionId: string, updates: Partial<Omit<TimelineTransition, 'id'>>) => set((state) => {
+  updateTransition: (
+    transitionId: string,
+    updates: Partial<Pick<TimelineTransition, 'type' | 'duration'>>,
+  ) => set((state) => {
     let changed = false;
     const newTransitions = state.transitions.map((transition) => {
       if (transition.id !== transitionId) {

--- a/src/store/timeline/transitionSlice.ts
+++ b/src/store/timeline/transitionSlice.ts
@@ -1,0 +1,70 @@
+import type { StoreApi } from 'zustand';
+import { logAction } from '../actionLogger';
+import type { TimelineState, TimelineTransition } from './types';
+import { withHistory } from './historySlice';
+
+type Set = StoreApi<TimelineState>['setState'];
+type Get = StoreApi<TimelineState>['getState'];
+
+function hasDuplicateTransition(
+  transitions: TimelineTransition[],
+  candidate: TimelineTransition,
+): boolean {
+  return transitions.some((transition) =>
+    transition.outClipId === candidate.outClipId
+    && transition.inClipId === candidate.inClipId
+    && transition.outTrackId === candidate.outTrackId
+    && transition.inTrackId === candidate.inTrackId,
+  );
+}
+
+export const createTransitionSlice = (set: Set, get: Get) => ({
+  transitions: [] as TimelineTransition[],
+
+  addTransition: (transition: TimelineTransition) => set((state) => {
+    if (hasDuplicateTransition(state.transitions, transition)) {
+      return state;
+    }
+
+    logAction(
+      'addTransition',
+      `id=${transition.id} out=${transition.outTrackId}/${transition.outClipId} in=${transition.inTrackId}/${transition.inClipId}`,
+    );
+
+    return withHistory(state, state.tracks, [...state.transitions, transition]);
+  }),
+
+  removeTransitionById: (transitionId: string) => set((state) => {
+    const newTransitions = state.transitions.filter((transition) => transition.id !== transitionId);
+    if (newTransitions.length === state.transitions.length) {
+      return state;
+    }
+
+    logAction('removeTransitionById', `id=${transitionId}`);
+    return withHistory(state, state.tracks, newTransitions);
+  }),
+
+  updateTransition: (transitionId: string, updates: Partial<Omit<TimelineTransition, 'id'>>) => set((state) => {
+    let changed = false;
+    const newTransitions = state.transitions.map((transition) => {
+      if (transition.id !== transitionId) {
+        return transition;
+      }
+
+      changed = true;
+      return { ...transition, ...updates };
+    });
+
+    if (!changed) {
+      return state;
+    }
+
+    logAction('updateTransition', `id=${transitionId} keys=${Object.keys(updates).join(',')}`);
+    return withHistory(state, state.tracks, newTransitions);
+  }),
+
+  findTransitionByClipId: (clipId: string) =>
+    get().transitions.find((transition) =>
+      transition.outClipId === clipId || transition.inClipId === clipId,
+    ),
+});

--- a/src/store/timeline/types.ts
+++ b/src/store/timeline/types.ts
@@ -199,6 +199,16 @@ export interface ClipTransition {
   duration: number; // オーバーラップ秒数（前クリップの末尾と当クリップの先頭が重なる）
 }
 
+export interface TimelineTransition {
+  id: string;
+  type: TransitionType;
+  duration: number;
+  outTrackId: string;
+  outClipId: string;
+  inTrackId: string;
+  inClipId: string;
+}
+
 export interface Clip {
   id: string;
   name: string;
@@ -274,6 +284,14 @@ export interface TrackSlice {
   toggleSolo: (trackId: string) => void;
 }
 
+export interface TransitionSlice {
+  transitions: TimelineTransition[];
+  addTransition: (transition: TimelineTransition) => void;
+  removeTransitionById: (transitionId: string) => void;
+  updateTransition: (transitionId: string, updates: Partial<Omit<TimelineTransition, 'id'>>) => void;
+  findTransitionByClipId: (clipId: string) => TimelineTransition | undefined;
+}
+
 export interface ClipSlice {
   addClip: (trackId: string, clip: Clip) => void;
   removeClip: (trackId: string, clipId: string) => void;
@@ -294,8 +312,13 @@ export interface ClipSlice {
   updateToneCurveKeyframeEasing: (trackId: string, clipId: string, time: number, easing: EasingType) => void;
 }
 
+export interface TimelineHistoryEntry {
+  tracks: Track[];
+  transitions: TimelineTransition[];
+}
+
 export interface HistorySlice {
-  _history: Track[][];
+  _history: TimelineHistoryEntry[];
   _historyIndex: number;
   undo: () => void;
   redo: () => void;
@@ -310,4 +333,4 @@ export interface ClipboardSlice {
   pasteClip: () => void;
 }
 
-export type TimelineState = PlaybackSlice & TrackSlice & ClipSlice & HistorySlice & ClipboardSlice;
+export type TimelineState = PlaybackSlice & TrackSlice & TransitionSlice & ClipSlice & HistorySlice & ClipboardSlice;

--- a/src/store/timeline/types.ts
+++ b/src/store/timeline/types.ts
@@ -288,7 +288,10 @@ export interface TransitionSlice {
   transitions: TimelineTransition[];
   addTransition: (transition: TimelineTransition) => void;
   removeTransitionById: (transitionId: string) => void;
-  updateTransition: (transitionId: string, updates: Partial<Omit<TimelineTransition, 'id'>>) => void;
+  updateTransition: (
+    transitionId: string,
+    updates: Partial<Pick<TimelineTransition, 'type' | 'duration'>>,
+  ) => void;
   findTransitionByClipId: (clipId: string) => TimelineTransition | undefined;
 }
 

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -16,8 +16,10 @@ export type {
   TimecodeOverlay,
   TransitionType,
   ClipTransition,
+  TimelineTransition,
   Clip,
   Track,
+  TimelineHistoryEntry,
   TimelineState,
 } from './timeline';
 

--- a/src/test/keyframeStoreActions.test.ts
+++ b/src/test/keyframeStoreActions.test.ts
@@ -5,12 +5,13 @@ import type { Clip } from '../store/timelineStore';
 function resetStore() {
   useTimelineStore.setState({
     tracks: [],
+    transitions: [],
     selectedClipId: null,
     selectedTrackId: null,
     currentTime: 0,
     isPlaying: false,
     pixelsPerSecond: 50,
-    _history: [[]],
+    _history: [{ tracks: [], transitions: [] }],
     _historyIndex: 0,
     _clipboard: null,
   });

--- a/src/test/timelineStore.test.ts
+++ b/src/test/timelineStore.test.ts
@@ -6,6 +6,7 @@ describe('timelineStore', () => {
     // Reset store before each test
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,

--- a/src/test/timelineStoreActions.test.ts
+++ b/src/test/timelineStoreActions.test.ts
@@ -6,12 +6,13 @@ import { DEFAULT_EFFECTS } from '../store/timelineStore';
 function resetStore() {
   useTimelineStore.setState({
     tracks: [],
+    transitions: [],
     selectedClipId: null,
     selectedTrackId: null,
     currentTime: 0,
     isPlaying: false,
     pixelsPerSecond: 50,
-    _history: [[]],
+    _history: [{ tracks: [], transitions: [] }],
     _historyIndex: 0,
     _clipboard: null,
   });

--- a/src/test/timelineTransitionStore.test.ts
+++ b/src/test/timelineTransitionStore.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useTimelineStore, type TimelineTransition } from '../store/timelineStore';
+
+function resetStore() {
+  useTimelineStore.setState({
+    tracks: [],
+    transitions: [],
+    selectedClipId: null,
+    selectedTrackId: null,
+    currentTime: 0,
+    isPlaying: false,
+    pixelsPerSecond: 50,
+    _history: [{ tracks: [], transitions: [] }],
+    _historyIndex: 0,
+    _clipboard: null,
+  });
+}
+
+function createTransition(overrides: Partial<TimelineTransition> = {}): TimelineTransition {
+  return {
+    id: 'transition-1',
+    type: 'crossfade',
+    duration: 1,
+    outTrackId: 'video-1',
+    outClipId: 'clip-1',
+    inTrackId: 'video-1',
+    inClipId: 'clip-2',
+    ...overrides,
+  };
+}
+
+describe('timeline transition store', () => {
+  beforeEach(resetStore);
+
+  it('should add a timeline transition', () => {
+    useTimelineStore.getState().addTransition(createTransition());
+
+    expect(useTimelineStore.getState().transitions).toHaveLength(1);
+    expect(useTimelineStore.getState().transitions[0].id).toBe('transition-1');
+  });
+
+  it('should remove a timeline transition by id', () => {
+    const store = useTimelineStore.getState();
+    store.addTransition(createTransition());
+    store.removeTransitionById('transition-1');
+
+    expect(useTimelineStore.getState().transitions).toHaveLength(0);
+  });
+
+  it('should update type and duration', () => {
+    const store = useTimelineStore.getState();
+    store.addTransition(createTransition());
+    store.updateTransition('transition-1', { type: 'wipe-left', duration: 2.5 });
+
+    expect(useTimelineStore.getState().transitions[0]).toMatchObject({
+      type: 'wipe-left',
+      duration: 2.5,
+    });
+  });
+
+  it('should find a transition by outgoing clip id', () => {
+    const transition = createTransition();
+    useTimelineStore.getState().addTransition(transition);
+
+    expect(useTimelineStore.getState().findTransitionByClipId('clip-1')).toEqual(transition);
+  });
+
+  it('should find a transition by incoming clip id', () => {
+    const transition = createTransition();
+    useTimelineStore.getState().addTransition(transition);
+
+    expect(useTimelineStore.getState().findTransitionByClipId('clip-2')).toEqual(transition);
+  });
+
+  it('should not add duplicate transitions for the same clip pair', () => {
+    const store = useTimelineStore.getState();
+    store.addTransition(createTransition({ id: 'transition-1' }));
+    store.addTransition(createTransition({ id: 'transition-2' }));
+
+    expect(useTimelineStore.getState().transitions).toHaveLength(1);
+    expect(useTimelineStore.getState().transitions[0].id).toBe('transition-1');
+  });
+
+  it('should support undo and redo', () => {
+    const store = useTimelineStore.getState();
+    store.addTransition(createTransition());
+    expect(useTimelineStore.getState().transitions).toHaveLength(1);
+
+    store.undo();
+    expect(useTimelineStore.getState().transitions).toHaveLength(0);
+
+    store.redo();
+    expect(useTimelineStore.getState().transitions).toHaveLength(1);
+  });
+});

--- a/src/test/trackMixing.test.ts
+++ b/src/test/trackMixing.test.ts
@@ -5,9 +5,10 @@ describe('Track Mixing (volume / mute / solo)', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
-      _history: [[]],
+      _history: [{ tracks: [], transitions: [] }],
       _historyIndex: 0,
     });
   });

--- a/src/test/undoRedo.test.ts
+++ b/src/test/undoRedo.test.ts
@@ -5,12 +5,13 @@ describe('undo/redo', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,
       isPlaying: false,
       pixelsPerSecond: 50,
-      _history: [[]],
+      _history: [{ tracks: [], transitions: [] }],
       _historyIndex: 0,
       _clipboard: null,
     });
@@ -120,12 +121,13 @@ describe('copy/paste', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,
       isPlaying: false,
       pixelsPerSecond: 50,
-      _history: [[]],
+      _history: [{ tracks: [], transitions: [] }],
       _historyIndex: 0,
       _clipboard: null,
     });


### PR DESCRIPTION
## Summary
- トランジションを `clip.transition` から独立エンティティ `TimelineTransition` に移行する基盤を実装
- クロストラックトランジション対応（#51）に向けた Phase 1-A

## 変更内容
- `TimelineTransition` インターフェースを `types.ts` に追加（`outTrackId/outClipId`, `inTrackId/inClipId` で両クリップを参照）
- `transitionSlice.ts` に CRUD アクション実装（`addTransition`, `removeTransition`, `updateTransition`, `findTransitionByClipId`）
- `historySlice` の `withHistory` を `transitions` フィールド対応に拡張
- ユニットテスト追加（`timelineTransitionStore.test.ts`）

## テスト計画
- [x] `npm run test` でテストがパスすること
- [x] `npm run lint` でエラーがないこと
- [x] `npm run build` でビルドが通ること

手動打鍵: UI に露出する変更なし（ストア内部の型定義とスライス追加のみ）。既存のトランジション機能が壊れていないことは以下で確認：
- [x] 既存のトランジション追加・削除が従来通り動作すること
- [x] Undo/Redo が従来通り動作すること

Closes #196