### PR TITLE
clip.transition → TimelineTransition マイグレーション関数（Issue #197）

### DIFF
--- a/src/test/transitionMigration.test.ts
+++ b/src/test/transitionMigration.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+import type { Track, TimelineTransition } from '../store/timelineStore';
+import {
+  migrateClipTransitionsToTimeline,
+  timelineTransitionsToClipTransitions,
+} from '../utils/transitionMigration';
+
+function createVideoTrack(id: string, clips: Track['clips']): Track {
+  return {
+    id,
+    type: 'video',
+    name: id,
+    clips,
+    volume: 1,
+    mute: false,
+    solo: false,
+  };
+}
+
+describe('transitionMigration', () => {
+  it('migrates same-track adjacent clip transitions into timeline transitions', () => {
+    const tracks: Track[] = [
+      createVideoTrack('video-1', [
+        {
+          id: 'clip-1',
+          name: 'Clip 1',
+          startTime: 0,
+          duration: 5,
+          filePath: 'a.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+        {
+          id: 'clip-2',
+          name: 'Clip 2',
+          startTime: 5,
+          duration: 5,
+          filePath: 'b.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+          transition: { type: 'crossfade', duration: 1 },
+        },
+      ]),
+    ];
+
+    expect(migrateClipTransitionsToTimeline(tracks)).toEqual([
+      {
+        id: 'transition-clip-1-clip-2',
+        type: 'crossfade',
+        duration: 1,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      },
+    ]);
+  });
+
+  it('migrates transitions across multiple tracks', () => {
+    const tracks: Track[] = [
+      createVideoTrack('video-1', [
+        {
+          id: 'clip-1',
+          name: 'Clip 1',
+          startTime: 0,
+          duration: 5,
+          filePath: 'a.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+        {
+          id: 'clip-2',
+          name: 'Clip 2',
+          startTime: 5,
+          duration: 5,
+          filePath: 'b.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+          transition: { type: 'wipe-left', duration: 0.5 },
+        },
+      ]),
+      createVideoTrack('video-2', [
+        {
+          id: 'clip-3',
+          name: 'Clip 3',
+          startTime: 0,
+          duration: 3,
+          filePath: 'c.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 3,
+        },
+        {
+          id: 'clip-4',
+          name: 'Clip 4',
+          startTime: 3,
+          duration: 4,
+          filePath: 'd.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 4,
+          transition: { type: 'dissolve', duration: 0.75 },
+        },
+      ]),
+    ];
+
+    expect(migrateClipTransitionsToTimeline(tracks)).toEqual([
+      {
+        id: 'transition-clip-1-clip-2',
+        type: 'wipe-left',
+        duration: 0.5,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      },
+      {
+        id: 'transition-clip-3-clip-4',
+        type: 'dissolve',
+        duration: 0.75,
+        outTrackId: 'video-2',
+        outClipId: 'clip-3',
+        inTrackId: 'video-2',
+        inClipId: 'clip-4',
+      },
+    ]);
+  });
+
+  it('ignores clips without transition and first clips with transition but no previous clip', () => {
+    const tracks: Track[] = [
+      createVideoTrack('video-1', [
+        {
+          id: 'clip-1',
+          name: 'Clip 1',
+          startTime: 0,
+          duration: 5,
+          filePath: 'a.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+          transition: { type: 'crossfade', duration: 1 },
+        },
+        {
+          id: 'clip-2',
+          name: 'Clip 2',
+          startTime: 5,
+          duration: 5,
+          filePath: 'b.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+      ]),
+    ];
+
+    expect(migrateClipTransitionsToTimeline(tracks)).toEqual([]);
+  });
+
+  it('returns cloned tracks with clip.transition restored for same-track transitions', () => {
+    const tracks: Track[] = [
+      createVideoTrack('video-1', [
+        {
+          id: 'clip-1',
+          name: 'Clip 1',
+          startTime: 0,
+          duration: 5,
+          filePath: 'a.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+        {
+          id: 'clip-2',
+          name: 'Clip 2',
+          startTime: 5,
+          duration: 5,
+          filePath: 'b.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+      ]),
+    ];
+    const transitions: TimelineTransition[] = [
+      {
+        id: 'transition-clip-1-clip-2',
+        type: 'crossfade',
+        duration: 1,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      },
+    ];
+
+    const migrated = timelineTransitionsToClipTransitions(transitions, tracks);
+
+    expect(migrated[0].clips[0].transition).toBeUndefined();
+    expect(migrated[0].clips[1].transition).toEqual({ type: 'crossfade', duration: 1 });
+    expect(tracks[0].clips[1].transition).toBeUndefined();
+  });
+
+  it('drops cross-track transitions on reverse conversion', () => {
+    const tracks: Track[] = [
+      createVideoTrack('video-1', [
+        {
+          id: 'clip-1',
+          name: 'Clip 1',
+          startTime: 0,
+          duration: 5,
+          filePath: 'a.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+      ]),
+      createVideoTrack('video-2', [
+        {
+          id: 'clip-2',
+          name: 'Clip 2',
+          startTime: 0,
+          duration: 5,
+          filePath: 'b.mp4',
+          sourceStartTime: 0,
+          sourceEndTime: 5,
+        },
+      ]),
+    ];
+
+    const migrated = timelineTransitionsToClipTransitions([
+      {
+        id: 'transition-cross-track',
+        type: 'crossfade',
+        duration: 1,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-2',
+        inClipId: 'clip-2',
+      },
+    ], tracks);
+
+    expect(migrated[0].clips[0].transition).toBeUndefined();
+    expect(migrated[1].clips[0].transition).toBeUndefined();
+  });
+
+  it('handles empty tracks and clips without error', () => {
+    expect(migrateClipTransitionsToTimeline([])).toEqual([]);
+    expect(timelineTransitionsToClipTransitions([], [])).toEqual([]);
+  });
+});

--- a/src/utils/transitionMigration.ts
+++ b/src/utils/transitionMigration.ts
@@ -1,0 +1,74 @@
+import type { Clip, Track, TimelineTransition } from '../store/timelineStore';
+
+function cloneTracks(tracks: Track[]): Track[] {
+  return tracks.map((track) => ({
+    ...track,
+    clips: track.clips.map((clip) => ({ ...clip })),
+  }));
+}
+
+function createTransitionId(outClipId: string, inClipId: string): string {
+  return `transition-${outClipId}-${inClipId}`;
+}
+
+function sortClipsByStartTime(clips: Clip[]): Clip[] {
+  return [...clips].sort((a, b) => a.startTime - b.startTime);
+}
+
+export function migrateClipTransitionsToTimeline(tracks: Track[]): TimelineTransition[] {
+  const transitions: TimelineTransition[] = [];
+
+  for (const track of tracks) {
+    const sortedClips = sortClipsByStartTime(track.clips);
+
+    for (let i = 0; i < sortedClips.length; i += 1) {
+      const incomingClip = sortedClips[i];
+      if (!incomingClip.transition || i === 0) {
+        continue;
+      }
+
+      const outgoingClip = sortedClips[i - 1];
+      transitions.push({
+        id: createTransitionId(outgoingClip.id, incomingClip.id),
+        type: incomingClip.transition.type,
+        duration: incomingClip.transition.duration,
+        outTrackId: track.id,
+        outClipId: outgoingClip.id,
+        inTrackId: track.id,
+        inClipId: incomingClip.id,
+      });
+    }
+  }
+
+  return transitions;
+}
+
+export function timelineTransitionsToClipTransitions(
+  transitions: TimelineTransition[],
+  tracks: Track[],
+): Track[] {
+  const clonedTracks = cloneTracks(tracks);
+
+  for (const transition of transitions) {
+    if (transition.outTrackId !== transition.inTrackId) {
+      continue;
+    }
+
+    const track = clonedTracks.find((candidate) => candidate.id === transition.inTrackId);
+    if (!track) {
+      continue;
+    }
+
+    const incomingClip = track.clips.find((clip) => clip.id === transition.inClipId);
+    if (!incomingClip) {
+      continue;
+    }
+
+    incomingClip.transition = {
+      type: transition.type,
+      duration: transition.duration,
+    };
+  }
+
+  return clonedTracks;
+}


### PR DESCRIPTION
## Summary
- 既存の `clip.transition` データを新しい `TimelineTransition` 独立エンティティに変換する純粋関数を実装
- Phase 1-B: データマイグレーション

## 変更内容
- `migrateClipTransitionsToTimeline`: 各クリップの `clip.transition` を `TimelineTransition[]` に変換。同一トラック内の前クリップを outgoing として自動解決
- `timelineTransitionsToClipTransitions`: 逆変換。クロストラックトランジションは除外
- ユニットテスト6件追加

## テスト計画
- [x] `npm run test` でテストがパスすること
- [x] `npm run lint` でエラーがないこと
- [x] `npm run build` でビルドが通ること

手動打鍵: UI に露出する変更なし（純粋関数の追加のみ）

Closes #197