### PR TITLE
プロジェクトファイル v3 スキーマ対応（Issue #198）

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -8,6 +8,7 @@ import { useExportStore } from './exportStore';
 import { useVideoPreviewStore } from './videoPreviewStore';
 import i18n from '../i18n';
 import { toRelativePath, resolveRelativePath, getDirectoryPath } from '../utils/pathUtils';
+import { migrateClipTransitionsToTimeline } from '../utils/transitionMigration';
 
 export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 export type LoadStatus = 'idle' | 'loading' | 'loaded' | 'error';
@@ -92,6 +93,7 @@ function buildProjectFile(projectName: string): ProjectFile {
     },
     timeline: {
       tracks,
+      transitions: timeline.transitions.map((transition) => ({ ...transition })),
     },
     exportSettings,
   };
@@ -128,7 +130,20 @@ function validateProjectFile(data: unknown): ProjectFile {
   if (!obj.timeline || typeof obj.timeline !== 'object') {
     throw new Error(i18n.t('project.timelineNotFound'));
   }
-  return data as ProjectFile;
+
+  const project = data as ProjectFile;
+  const transitions = project.schemaVersion >= 3
+    ? project.timeline.transitions ?? []
+    : migrateClipTransitionsToTimeline(project.timeline.tracks);
+
+  return {
+    ...project,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    timeline: {
+      tracks: project.timeline.tracks,
+      transitions,
+    },
+  };
 }
 
 function applyProjectToStores(project: ProjectFile): void {
@@ -151,14 +166,15 @@ function applyProjectToStores(project: ProjectFile): void {
     ...track,
     clips: track.clips.map((clip) => ({ ...clip })),
   }));
+  const transitions = project.timeline.transitions.map((transition) => ({ ...transition }));
   useTimelineStore.setState({
     tracks,
-    transitions: [],
+    transitions,
     selectedClipId: null,
     selectedTrackId: null,
     currentTime: 0,
     isPlaying: false,
-    _history: [{ tracks, transitions: [] }],
+    _history: [{ tracks, transitions }],
     _historyIndex: 0,
   });
 
@@ -533,7 +549,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 // タイムラインの変更を監視して isDirty を自動更新し、自動保存をスケジュール
 useTimelineStore.subscribe(
   (state, prevState) => {
-    if (state.tracks !== prevState.tracks) {
+    if (state.tracks !== prevState.tracks || state.transitions !== prevState.transitions) {
       const { loadStatus } = useProjectStore.getState();
       // プロジェクト読み込み中の変更は無視
       if (loadStatus !== 'loading') {

--- a/src/test/projectFile.test.ts
+++ b/src/test/projectFile.test.ts
@@ -76,6 +76,7 @@ describe('ProjectFile schema', () => {
           ],
         },
       ],
+      transitions: [],
     },
     exportSettings: {
       format: 'mp4',
@@ -86,15 +87,16 @@ describe('ProjectFile schema', () => {
     },
   };
 
-  it('CURRENT_SCHEMA_VERSION が 2 である', () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(2);
+  it('CURRENT_SCHEMA_VERSION が 3 である', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(3);
   });
 
   it('有効なプロジェクトファイルが型に適合する', () => {
-    expect(validProject.schemaVersion).toBe(2);
+    expect(validProject.schemaVersion).toBe(3);
     expect(validProject.appVersion).toBe('0.1.0');
     expect(validProject.metadata.name).toBe('テストプロジェクト');
     expect(validProject.timeline.tracks).toHaveLength(3);
+    expect(validProject.timeline.transitions).toEqual([]);
   });
 
   it('タイムラインのトラック型が正しい', () => {

--- a/src/test/projectStore.test.ts
+++ b/src/test/projectStore.test.ts
@@ -86,10 +86,11 @@ describe('projectStore', () => {
     const call = vi.mocked(invoke).mock.calls[0];
     const args = call[1] as { content: string };
     const parsed = JSON.parse(args.content);
-    expect(parsed.schemaVersion).toBe(2);
+    expect(parsed.schemaVersion).toBe(3);
     expect(parsed.appVersion).toBe('0.1.0');
     expect(parsed.metadata.name).toBe('無題のプロジェクト');
     expect(parsed.timeline).toBeDefined();
+    expect(parsed.timeline.transitions).toEqual([]);
     expect(parsed.exportSettings).toBeDefined();
   });
 
@@ -166,7 +167,7 @@ describe('projectStore', () => {
   // --- loadProject ---
 
   const validProjectJson: ProjectFile = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     appVersion: '0.1.0',
     createdAt: '2026-03-08T12:00:00.000Z',
     updatedAt: '2026-03-08T12:00:00.000Z',
@@ -193,8 +194,36 @@ describe('projectStore', () => {
           ],
         },
       ],
+      transitions: [],
     },
     exportSettings: { format: 'mp4', width: 1920, height: 1080, bitrate: '8M', fps: 30 },
+  };
+
+  const validProjectJsonV2 = {
+    ...validProjectJson,
+    schemaVersion: 2,
+    timeline: {
+      tracks: [
+        {
+          ...validProjectJson.timeline.tracks[0],
+          clips: [
+            {
+              ...validProjectJson.timeline.tracks[0].clips[0],
+            },
+            {
+              id: 'clip-2',
+              name: 'next.mp4',
+              startTime: 10,
+              duration: 5,
+              filePath: '/videos/next.mp4',
+              sourceStartTime: 0,
+              sourceEndTime: 5,
+              transition: { type: 'crossfade' as const, duration: 1 },
+            },
+          ],
+        },
+      ],
+    },
   };
 
   it('loadProjectFromPath でタイムラインが復元される', async () => {
@@ -215,9 +244,75 @@ describe('projectStore', () => {
 
     const timeline = useTimelineStore.getState();
     expect(timeline.tracks).toHaveLength(1);
+    expect(timeline.transitions).toEqual([]);
     expect(timeline.tracks[0].id).toBe('video-1');
     expect(timeline.tracks[0].clips).toHaveLength(1);
     expect(timeline.tracks[0].clips[0].name).toBe('sample.mp4');
+  });
+
+  it('loadProjectFromPath で v2 プロジェクトを読み込むと transitions が生成される', async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'read_project') return JSON.stringify(validProjectJsonV2);
+      if (cmd === 'get_file_info') {
+        const path = args?.path as string;
+        return { name: path.split('/').pop(), path, size: 1000, last_modified: 0 };
+      }
+      return undefined;
+    });
+
+    await useProjectStore.getState().loadProjectFromPath('/tmp/v2.qcut');
+
+    const timeline = useTimelineStore.getState();
+    expect(timeline.transitions).toEqual([
+      {
+        id: 'transition-clip-1-clip-2',
+        type: 'crossfade',
+        duration: 1,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      },
+    ]);
+  });
+
+  it('saveProject が transitions を含む v3 形式で保存する', async () => {
+    useTimelineStore.setState({
+      tracks: validProjectJson.timeline.tracks,
+      transitions: [
+        {
+          id: 'transition-clip-1-clip-2',
+          type: 'crossfade',
+          duration: 1,
+          outTrackId: 'video-1',
+          outClipId: 'clip-1',
+          inTrackId: 'video-1',
+          inClipId: 'clip-2',
+        },
+      ],
+    });
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    useProjectStore.setState({ projectFilePath: '/tmp/test.qcut' });
+
+    await useProjectStore.getState().saveProject();
+
+    const saveCall = vi.mocked(invoke).mock.calls.find((c) => c[0] === 'save_project');
+    const args = saveCall![1] as { content: string };
+    const parsed = JSON.parse(args.content);
+
+    expect(parsed.schemaVersion).toBe(3);
+    expect(parsed.timeline.transitions).toEqual([
+      {
+        id: 'transition-clip-1-clip-2',
+        type: 'crossfade',
+        duration: 1,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      },
+    ]);
   });
 
   it('loadProjectFromPath で動画URLがvideoPreviewStoreに登録される', async () => {

--- a/src/types/projectFile.ts
+++ b/src/types/projectFile.ts
@@ -1,4 +1,4 @@
-import type { Clip, Track } from '../store/timelineStore';
+import type { Clip, TimelineTransition, Track } from '../store/timelineStore';
 import type { ExportSettings } from '../store/exportStore';
 
 /**
@@ -9,7 +9,7 @@ import type { ExportSettings } from '../store/exportStore';
  * - 破壊的変更（既存フィールドの型変更・削除）: メジャーバージョンを上げる (1 → 100)
  * - 読み込み時はマイグレーション関数で古いバージョンを最新に変換する
  */
-export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_SCHEMA_VERSION = 3;
 
 // --- プロジェクトファイルのルート ---
 
@@ -37,6 +37,7 @@ export interface ProjectMetadata {
 
 export interface ProjectTimeline {
   tracks: ProjectTrack[];
+  transitions: TimelineTransition[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- プロジェクトファイルに `TimelineTransition` を保存/読み込みするための v3 スキーマ対応
- v2 形式の既存プロジェクトとの互換性を維持
- Phase 1-C

## 変更内容
- `CURRENT_SCHEMA_VERSION` を 2 → 3 に更新
- `ProjectTimeline` に `transitions: TimelineTransition[]` フィールド追加
- v2 プロジェクト読み込み時に `migrateClipTransitionsToTimeline` で自動変換
- `applyProjectToStores` で `transitions` をストアに復元
- タイムライン変更監視に `transitions` の変更検知を追加
- テスト追加: v2 マイグレーション、v3 保存/読み込みラウンドトリップ

## テスト計画
- [x] `npm run test` でテストがパスすること
- [x] `npm run lint` でエラーがないこと
- [x] `npm run build` でビルドが通ること

手動打鍵:
- [ ] 既存の v2 プロジェクトファイルを開いて正常に読み込めること
- [ ] プロジェクトを保存して再度開いた際にデータが維持されること
- [ ] トランジション付きプロジェクトの保存/読み込みが正常に動作すること

Closes #198