### PR TITLE
ストアAPI移行: clip.transition 廃止 → TimelineTransition ベース（Issue #199）

### DIFF
--- a/src/components/Timeline/ClipContextMenu.tsx
+++ b/src/components/Timeline/ClipContextMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useTimelineStore, Clip as ClipType, DEFAULT_EFFECTS, type TransitionType } from '../../store/timelineStore';
+import { useTimelineStore, Clip as ClipType, DEFAULT_EFFECTS, type TimelineTransition, type TransitionType } from '../../store/timelineStore';
 import { TransitionSubmenu } from './TransitionSubmenu';
 import { clampMenuPosition } from './clipUtils';
 
@@ -17,8 +17,8 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
   const {
     removeClip,
     splitClipAtTime,
-    setTransition,
-    removeTransition,
+    addTransition,
+    removeTransitionById,
     addTrack,
     addClip,
     updateClip,
@@ -29,7 +29,19 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
   const [showTransitionSubmenu, setShowTransitionSubmenu] = useState(false);
   const contextMenuRef = useRef<HTMLDivElement>(null);
 
-  const hasTransition = !!clip.transition;
+  const incomingTransition = useTimelineStore((state) =>
+    state.transitions.find((transition) => transition.inClipId === clip.id && transition.inTrackId === trackId),
+  );
+  const hasTransition = !!incomingTransition;
+
+  const findPreviousClip = (): ClipType | null => {
+    const track = useTimelineStore.getState().tracks.find((candidate) => candidate.id === trackId);
+    if (!track) return null;
+    const sortedClips = [...track.clips].sort((a, b) => a.startTime - b.startTime);
+    const currentIndex = sortedClips.findIndex((candidate) => candidate.id === clip.id);
+    if (currentIndex <= 0) return null;
+    return sortedClips[currentIndex - 1];
+  };
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -45,7 +57,9 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
 
   const handleRemoveTransition = (e: React.MouseEvent) => {
     e.stopPropagation();
-    removeTransition(trackId, clip.id);
+    if (incomingTransition) {
+      removeTransitionById(incomingTransition.id);
+    }
     onClose();
   };
 
@@ -76,7 +90,30 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
   };
 
   const handleSelectTransition = (presetType: TransitionType, presetDuration: number) => {
-    setTransition(trackId, clip.id, { type: presetType, duration: presetDuration });
+    const previousClip = findPreviousClip();
+    if (!previousClip) {
+      onClose();
+      return;
+    }
+
+    const transition: TimelineTransition = incomingTransition ?? {
+      id: `transition-${previousClip.id}-${clip.id}`,
+      type: presetType,
+      duration: presetDuration,
+      outTrackId: trackId,
+      outClipId: previousClip.id,
+      inTrackId: trackId,
+      inClipId: clip.id,
+    };
+
+    if (incomingTransition) {
+      useTimelineStore.getState().updateTransition(incomingTransition.id, {
+        type: presetType,
+        duration: presetDuration,
+      });
+    } else {
+      addTransition(transition);
+    }
     onClose();
   };
 

--- a/src/components/Timeline/Track.tsx
+++ b/src/components/Timeline/Track.tsx
@@ -32,8 +32,10 @@ interface TrackProps {
 
 function Track({ track }: TrackProps) {
   const pixelsPerSecond = useTimelineStore((s) => s.pixelsPerSecond);
-  const transitions = useTimelineStore((s) =>
-    s.transitions.filter((transition) => transition.inTrackId === track.id && transition.outTrackId === track.id),
+  const allTransitions = useTimelineStore((s) => s.transitions);
+  const transitions = useMemo(
+    () => allTransitions.filter((transition) => transition.inTrackId === track.id && transition.outTrackId === track.id),
+    [allTransitions, track.id],
   );
   const overlaps = useMemo(() => computeOverlaps(track.clips), [track.clips]);
 

--- a/src/components/Timeline/Track.tsx
+++ b/src/components/Timeline/Track.tsx
@@ -32,6 +32,9 @@ interface TrackProps {
 
 function Track({ track }: TrackProps) {
   const pixelsPerSecond = useTimelineStore((s) => s.pixelsPerSecond);
+  const transitions = useTimelineStore((s) =>
+    s.transitions.filter((transition) => transition.inTrackId === track.id && transition.outTrackId === track.id),
+  );
   const overlaps = useMemo(() => computeOverlaps(track.clips), [track.clips]);
 
   return (
@@ -50,17 +53,18 @@ function Track({ track }: TrackProps) {
             }}
           />
         ))}
-        {track.clips
-          .filter(clip => clip.transition)
-          .map(clip => (
+        {transitions
+          .map((transition) => {
+            const incomingClip = track.clips.find((clip) => clip.id === transition.inClipId);
+            if (!incomingClip) return null;
+            return (
             <TransitionIndicator
-              key={`transition-${clip.id}`}
-              transition={clip.transition!}
-              clipId={clip.id}
-              trackId={track.id}
-              clipStartTime={clip.startTime}
+              key={`transition-${transition.id}`}
+              transition={transition}
+              clipStartTime={incomingClip.startTime}
             />
-          ))}
+            );
+          })}
       </div>
     </div>
   );

--- a/src/components/Timeline/TransitionIndicator.tsx
+++ b/src/components/Timeline/TransitionIndicator.tsx
@@ -1,21 +1,19 @@
 import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useTimelineStore, type ClipTransition } from '../../store/timelineStore';
+import { useTimelineStore, type TimelineTransition } from '../../store/timelineStore';
 import { TransitionPopover } from './TransitionPopover';
 import { TransitionMenu } from './TransitionMenu';
 import { computeIndicatorLayout } from './transitionLayout';
 import { TRANSITION_I18N_KEYS } from './transitionConstants';
 
 interface TransitionIndicatorProps {
-  transition: ClipTransition;
-  clipId: string;
-  trackId: string;
+  transition: TimelineTransition;
   clipStartTime: number;
 }
 
-function TransitionIndicator({ transition, clipId, trackId, clipStartTime }: TransitionIndicatorProps) {
+function TransitionIndicator({ transition, clipStartTime }: TransitionIndicatorProps) {
   const { t } = useTranslation();
-  const { pixelsPerSecond, removeTransition } = useTimelineStore();
+  const { pixelsPerSecond, removeTransitionById } = useTimelineStore();
   const [showPopover, setShowPopover] = useState(false);
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
@@ -41,7 +39,7 @@ function TransitionIndicator({ transition, clipId, trackId, clipStartTime }: Tra
   };
 
   const handleRemove = () => {
-    removeTransition(trackId, clipId);
+    removeTransitionById(transition.id);
     setShowContextMenu(false);
   };
 
@@ -64,8 +62,6 @@ function TransitionIndicator({ transition, clipId, trackId, clipStartTime }: Tra
       {showPopover && (
         <TransitionPopover
           transition={transition}
-          clipId={clipId}
-          trackId={trackId}
           popoverPos={popoverPos}
           indicatorRef={indicatorRef}
           onClose={() => setShowPopover(false)}

--- a/src/components/Timeline/TransitionPopover.tsx
+++ b/src/components/Timeline/TransitionPopover.tsx
@@ -1,13 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useTimelineStore, type ClipTransition, type TransitionType } from '../../store/timelineStore';
+import { useTimelineStore, type TimelineTransition, type TransitionType } from '../../store/timelineStore';
 import { useTransitionPresetStore, BUILT_IN_PRESETS } from '../../store/transitionPresetStore';
 import { TRANSITION_TYPES, TRANSITION_I18N_KEYS } from './transitionConstants';
 
 interface TransitionPopoverProps {
-  transition: ClipTransition;
-  clipId: string;
-  trackId: string;
+  transition: TimelineTransition;
   popoverPos: { x: number; y: number };
   indicatorRef: React.RefObject<HTMLDivElement | null>;
   onClose: () => void;
@@ -15,14 +13,12 @@ interface TransitionPopoverProps {
 
 export function TransitionPopover({
   transition,
-  clipId,
-  trackId,
   popoverPos: initialPopoverPos,
   indicatorRef,
   onClose,
 }: TransitionPopoverProps) {
   const { t } = useTranslation();
-  const { setTransition } = useTimelineStore();
+  const { updateTransition } = useTimelineStore();
   const customPresets = useTransitionPresetStore((s) => s.customPresets);
   const allPresets = [...BUILT_IN_PRESETS, ...customPresets];
   const addPreset = useTransitionPresetStore((s) => s.addPreset);
@@ -33,13 +29,13 @@ export function TransitionPopover({
   const [popoverPos, setPopoverPos] = useState(initialPopoverPos);
 
   const handleSelectType = (type: TransitionType) => {
-    setTransition(trackId, clipId, { ...transition, type });
+    updateTransition(transition.id, { type });
     onClose();
   };
 
   const handleDurationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const duration = parseFloat(e.target.value);
-    setTransition(trackId, clipId, { ...transition, duration });
+    updateTransition(transition.id, { duration });
   };
 
   // ポップオーバーが画面外にはみ出る場合、位置を自動補正
@@ -85,7 +81,7 @@ export function TransitionPopover({
                   className="transition-popover-item"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setTransition(trackId, clipId, { type: preset.type, duration: preset.duration });
+                    updateTransition(transition.id, { type: preset.type, duration: preset.duration });
                   }}
                 >
                   {preset.isBuiltIn ? t(preset.name) : preset.name}

--- a/src/components/VideoPreview/usePlaybackLoop.ts
+++ b/src/components/VideoPreview/usePlaybackLoop.ts
@@ -157,7 +157,7 @@ export const usePlaybackLoop = ({
         const inUrl = urls[incomingClip.filePath];
         const incomingSourceTime =
           incomingClip.sourceStartTime +
-          (currentTimeRef.current - (incomingClip.startTime - incomingClip.transition!.duration));
+          (currentTimeRef.current - (incomingClip.startTime - transition.duration));
         if (
           inUrl &&
           inUrl !== loadedTransitionVideoUrl.current &&

--- a/src/components/VideoPreview/useTransitionEffect.ts
+++ b/src/components/VideoPreview/useTransitionEffect.ts
@@ -8,6 +8,7 @@ export interface TransitionInfo {
   incomingClip: ClipType;
   progress: number; // 0→1 (0=outgoing only, 1=incoming only)
   transitionType: TransitionType;
+  duration: number;
 }
 
 interface UseTransitionEffectParams {
@@ -37,24 +38,26 @@ export const useTransitionEffect = ({
 
   const findTransitionAtTime = useCallback(
     (time: number): TransitionInfo | null => {
-      const currentTracks = useTimelineStore.getState().tracks;
-      for (const track of currentTracks) {
-        if (track.type !== 'video') continue;
-        for (const clip of track.clips) {
-          if (!clip.transition) continue;
-          const overlapStart = clip.startTime - clip.transition.duration;
-          const overlapEnd = clip.startTime;
-          if (time >= overlapStart && time < overlapEnd) {
-            const outgoing = findClipAtTime(time);
-            if (!outgoing || outgoing.id === clip.id) continue;
-            const progress = (time - overlapStart) / clip.transition.duration;
-            return {
-              outgoingClip: outgoing,
-              incomingClip: clip,
-              progress,
-              transitionType: clip.transition.type,
-            };
-          }
+      const { tracks, transitions } = useTimelineStore.getState();
+      for (const transition of transitions) {
+        const incomingClip = tracks
+          .find((track) => track.id === transition.inTrackId)
+          ?.clips.find((clip) => clip.id === transition.inClipId);
+        if (!incomingClip) continue;
+
+        const overlapStart = incomingClip.startTime - transition.duration;
+        const overlapEnd = incomingClip.startTime;
+        if (time >= overlapStart && time < overlapEnd) {
+          const outgoing = findClipAtTime(time);
+          if (!outgoing || outgoing.id === incomingClip.id) continue;
+          const progress = (time - overlapStart) / transition.duration;
+          return {
+            outgoingClip: outgoing,
+            incomingClip,
+            progress,
+            transitionType: transition.type,
+            duration: transition.duration,
+          };
         }
       }
       return null;

--- a/src/store/timeline/clipSlice.ts
+++ b/src/store/timeline/clipSlice.ts
@@ -1,6 +1,6 @@
 import type { StoreApi } from 'zustand';
 import { logAction } from '../actionLogger';
-import type { TimelineState, Clip, ClipTransition, ClipEffects, Keyframe, EasingType, ToneCurveKeyframe } from './types';
+import type { TimelineState, Clip, ClipEffects, Keyframe, EasingType, ToneCurveKeyframe } from './types';
 import { withHistory } from './historySlice';
 
 type Set = StoreApi<TimelineState>['setState'];
@@ -126,36 +126,6 @@ export const createClipSlice = (set: Set) => ({
       selectedClipId: null,
       selectedTrackId: null,
     };
-  }),
-
-  setTransition: (trackId: string, clipId: string, transition: ClipTransition) => set((state) => {
-    logAction('setTransition', `track=${trackId} clip=${clipId} type=${transition.type}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip =>
-              clip.id === clipId ? { ...clip, transition } : clip
-            ),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  removeTransition: (trackId: string, clipId: string) => set((state) => {
-    logAction('removeTransition', `track=${trackId} clip=${clipId}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip =>
-              clip.id === clipId ? { ...clip, transition: undefined } : clip
-            ),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
   }),
 
   addKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, keyframe: Keyframe) => set((state) => {

--- a/src/store/timeline/types.ts
+++ b/src/store/timeline/types.ts
@@ -236,9 +236,6 @@ export interface Clip {
   // テキストオーバーレイ
   textProperties?: TextProperties;
 
-  // トランジション（前のクリップとの境界に適用）
-  transition?: ClipTransition;
-
   // タイムコードオーバーレイ
   timecodeOverlay?: TimecodeOverlay;
 }
@@ -302,8 +299,6 @@ export interface ClipSlice {
   updateClipSilent: (trackId: string, clipId: string, updates: Partial<Clip>) => void;
   splitClipAtTime: (trackId: string, clipId: string, splitTime: number) => void;
   deleteSelectedClip: () => void;
-  setTransition: (trackId: string, clipId: string, transition: ClipTransition) => void;
-  removeTransition: (trackId: string, clipId: string) => void;
   moveClipToTrack: (fromTrackId: string, clipId: string, toTrackId: string) => void;
   addKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, keyframe: Keyframe) => void;
   removeKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number) => void;

--- a/src/test/clipContextMenu.test.ts
+++ b/src/test/clipContextMenu.test.ts
@@ -9,6 +9,7 @@ describe('ClipContextMenu store actions', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,
@@ -114,23 +115,35 @@ describe('ClipContextMenu store actions', () => {
   });
 
   describe('トランジション', () => {
-    it('setTransition でトランジションが追加される', () => {
-      const { setTransition } = useTimelineStore.getState();
-      setTransition('video-1', 'clip-2', { type: 'wipe-left', duration: 0.5 });
+    it('addTransition でトランジションが追加される', () => {
+      const { addTransition } = useTimelineStore.getState();
+      addTransition({
+        id: 'transition-clip-1-clip-2',
+        type: 'wipe-left',
+        duration: 0.5,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      });
 
-      const track = useTimelineStore.getState().tracks.find(t => t.id === 'video-1');
-      const clip2 = track!.clips.find(c => c.id === 'clip-2');
-      expect(clip2!.transition).toEqual({ type: 'wipe-left', duration: 0.5 });
+      expect(useTimelineStore.getState().transitions[0]).toMatchObject({ type: 'wipe-left', duration: 0.5 });
     });
 
-    it('removeTransition でトランジションが削除される', () => {
-      const { setTransition, removeTransition } = useTimelineStore.getState();
-      setTransition('video-1', 'clip-2', { type: 'dissolve', duration: 1.0 });
-      removeTransition('video-1', 'clip-2');
+    it('removeTransitionById でトランジションが削除される', () => {
+      const { addTransition, removeTransitionById } = useTimelineStore.getState();
+      addTransition({
+        id: 'transition-clip-1-clip-2',
+        type: 'dissolve',
+        duration: 1.0,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      });
+      removeTransitionById('transition-clip-1-clip-2');
 
-      const track = useTimelineStore.getState().tracks.find(t => t.id === 'video-1');
-      const clip2 = track!.clips.find(c => c.id === 'clip-2');
-      expect(clip2!.transition).toBeUndefined();
+      expect(useTimelineStore.getState().transitions).toEqual([]);
     });
   });
 

--- a/src/test/projectFile.test.ts
+++ b/src/test/projectFile.test.ts
@@ -104,10 +104,9 @@ describe('ProjectFile schema', () => {
     expect(types).toEqual(['video', 'audio', 'text']);
   });
 
-  it('クリップにエフェクト・テキスト・トランジションがオプショナルで設定できる', () => {
+  it('クリップにエフェクト・テキストがオプショナルで設定できる', () => {
     const videoClip = validProject.timeline.tracks[0].clips[0];
     expect(videoClip.effects).toBeUndefined();
-    expect(videoClip.transition).toBeUndefined();
 
     const textClip = validProject.timeline.tracks[2].clips[0];
     expect(textClip.textProperties).toBeDefined();
@@ -143,15 +142,30 @@ describe('ProjectFile schema', () => {
         echoDelay: 0,
         echoDecay: 0.3,
         reverbAmount: 0,
-      },
-      transition: {
-        type: 'crossfade',
-        duration: 0.5,
+        colorTemperature: 0,
+        hue: 0,
+        hslRedSat: 0,
+        hslYellowSat: 0,
+        hslGreenSat: 0,
+        hslCyanSat: 0,
+        hslBlueSat: 0,
+        hslMagentaSat: 0,
+        liftR: 0,
+        liftG: 0,
+        liftB: 0,
+        gammaR: 0,
+        gammaG: 0,
+        gammaB: 0,
+        gainR: 0,
+        gainG: 0,
+        gainB: 0,
+        blurAmount: 0,
+        sharpenAmount: 0,
+        monochrome: 0,
       },
     };
 
     expect(clipWithEffects.effects?.brightness).toBe(1.2);
-    expect(clipWithEffects.transition?.type).toBe('crossfade');
   });
 
   it('createdAt / updatedAt が ISO 8601 形式の文字列である', () => {

--- a/src/test/projectStore.test.ts
+++ b/src/test/projectStore.test.ts
@@ -251,10 +251,10 @@ describe('projectStore', () => {
   });
 
   it('loadProjectFromPath で v2 プロジェクトを読み込むと transitions が生成される', async () => {
-    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
       if (cmd === 'read_project') return JSON.stringify(validProjectJsonV2);
       if (cmd === 'get_file_info') {
-        const path = args?.path as string;
+        const path = (args as { path: string } | undefined)?.path as string;
         return { name: path.split('/').pop(), path, size: 1000, last_modified: 0 };
       }
       return undefined;
@@ -514,6 +514,7 @@ describe('projectStore', () => {
             filePath: 'assets/sample.mp4',
           }],
         }],
+        transitions: [],
       },
     };
 
@@ -679,7 +680,7 @@ describe('projectStore', () => {
       { name: 'Project1', path: '/tmp/project1.qcut', lastOpened: 1000 },
       { name: 'Project2', path: '/tmp/project2.qcut', lastOpened: 2000 },
     ];
-    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
       if (cmd === 'read_recent_projects') return JSON.stringify(recentData);
       if (cmd === 'get_file_info') {
         if ((args as { path: string }).path === '/tmp/project2.qcut') throw new Error('not found');
@@ -811,6 +812,7 @@ describe('projectStore', () => {
         solo: false,
         clips: [clipWithAllProperties],
       }],
+      transitions: [],
     },
   };
 

--- a/src/test/timelineStore.test.ts
+++ b/src/test/timelineStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useTimelineStore, type ClipTransition } from '../store/timelineStore';
+import { useTimelineStore, type TimelineTransition } from '../store/timelineStore';
 
 describe('timelineStore', () => {
   beforeEach(() => {
@@ -45,6 +45,7 @@ describe('timelineStore', () => {
 
     const state = useTimelineStore.getState();
     const track = state.tracks.find(t => t.id === 'video-1');
+    expect(track).toBeDefined();
     expect(track.clips).toHaveLength(1);
     expect(track.clips[0].id).toBe('test-clip');
   });
@@ -115,7 +116,15 @@ describe('timelineStore', () => {
   });
 
   describe('transition', () => {
-    const transition: ClipTransition = { type: 'crossfade', duration: 1.0 };
+    const transition: TimelineTransition = {
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    };
 
     beforeEach(() => {
       const { addTrack, addClip } = useTimelineStore.getState();
@@ -140,45 +149,40 @@ describe('timelineStore', () => {
       });
     });
 
-    it('should set transition on a clip', () => {
-      const { setTransition } = useTimelineStore.getState();
-      setTransition('video-1', 'clip-2', transition);
+    it('should add transition entity', () => {
+      const { addTransition } = useTimelineStore.getState();
+      addTransition(transition);
 
       const state = useTimelineStore.getState();
-      const track = state.tracks.find(t => t.id === 'video-1');
-      const clip = track!.clips.find(c => c.id === 'clip-2');
-      expect(clip!.transition).toEqual(transition);
+      expect(state.transitions).toEqual([transition]);
     });
 
-    it('should remove transition from a clip', () => {
-      const { setTransition, removeTransition } = useTimelineStore.getState();
-      setTransition('video-1', 'clip-2', transition);
-      removeTransition('video-1', 'clip-2');
+    it('should remove transition by id', () => {
+      const { addTransition, removeTransitionById } = useTimelineStore.getState();
+      addTransition(transition);
+      removeTransitionById(transition.id);
 
       const state = useTimelineStore.getState();
-      const track = state.tracks.find(t => t.id === 'video-1');
-      const clip = track!.clips.find(c => c.id === 'clip-2');
-      expect(clip!.transition).toBeUndefined();
+      expect(state.transitions).toEqual([]);
     });
 
-    it('should not affect other clips when setting transition', () => {
-      const { setTransition } = useTimelineStore.getState();
-      setTransition('video-1', 'clip-2', transition);
+    it('should not add duplicate transitions', () => {
+      const { addTransition } = useTimelineStore.getState();
+      addTransition(transition);
+      addTransition({ ...transition, id: 'transition-duplicate' });
 
-      const state = useTimelineStore.getState();
-      const track = state.tracks.find(t => t.id === 'video-1');
-      const clip1 = track!.clips.find(c => c.id === 'clip-1');
-      expect(clip1!.transition).toBeUndefined();
+      expect(useTimelineStore.getState().transitions).toHaveLength(1);
     });
 
-    it('should handle setting transition on non-existent clip gracefully', () => {
-      const { setTransition } = useTimelineStore.getState();
-      setTransition('video-1', 'non-existent', transition);
+    it('should update transition type and duration', () => {
+      const { addTransition, updateTransition } = useTimelineStore.getState();
+      addTransition(transition);
+      updateTransition(transition.id, { type: 'dissolve', duration: 2.5 });
 
-      const state = useTimelineStore.getState();
-      const track = state.tracks.find(t => t.id === 'video-1');
-      expect(track!.clips).toHaveLength(2);
-      expect(track!.clips.every(c => c.transition === undefined)).toBe(true);
+      expect(useTimelineStore.getState().transitions[0]).toMatchObject({
+        type: 'dissolve',
+        duration: 2.5,
+      });
     });
   });
 });

--- a/src/test/transitionExport.test.ts
+++ b/src/test/transitionExport.test.ts
@@ -10,6 +10,7 @@ describe('transition export data', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,
@@ -48,47 +49,75 @@ describe('transition export data', () => {
     });
   });
 
-  it('should include transition data in clip when set', () => {
-    const { setTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+  it('should include transition data in export settings when set', () => {
+    const { addTransition } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
 
     const state = useTimelineStore.getState();
-    const track = state.tracks.find(t => t.id === 'video-1')!;
-    const clip2 = track.clips.find(c => c.id === 'clip-2')!;
-
-    expect(clip2.transition).toEqual({ type: 'crossfade', duration: 1.0 });
-    // JSON シリアライズ時に transition が含まれることを確認
-    const json = JSON.stringify(clip2);
+    const json = JSON.stringify(state.transitions);
     const parsed = JSON.parse(json);
-    expect(parsed.transition).toEqual({ type: 'crossfade', duration: 1.0 });
+    expect(parsed[0]).toEqual({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
   });
 
   it('should not include transition data when not set', () => {
-    const state = useTimelineStore.getState();
-    const track = state.tracks.find(t => t.id === 'video-1')!;
-    const clip1 = track.clips.find(c => c.id === 'clip-1')!;
-
-    expect(clip1.transition).toBeUndefined();
+    expect(useTimelineStore.getState().transitions).toEqual([]);
   });
 
-  it('should serialize tracks with mixed transition states', () => {
-    const { setTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
-    setTransition('video-1', 'clip-3', { type: 'wipe-left', duration: 0.5 });
+  it('should serialize multiple transitions independently from tracks', () => {
+    const { addTransition } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
+    addTransition({
+      id: 'transition-clip-2-clip-3',
+      type: 'wipe-left',
+      duration: 0.5,
+      outTrackId: 'video-1',
+      outClipId: 'clip-2',
+      inTrackId: 'video-1',
+      inClipId: 'clip-3',
+    });
 
     const state = useTimelineStore.getState();
-    const tracks = state.tracks;
-    const serialized = JSON.parse(JSON.stringify(tracks));
-
-    const videoTrack = serialized.find((t: { id: string }) => t.id === 'video-1');
-    expect(videoTrack.clips[0].transition).toBeUndefined();
-    expect(videoTrack.clips[1].transition).toEqual({ type: 'crossfade', duration: 1.0 });
-    expect(videoTrack.clips[2].transition).toEqual({ type: 'wipe-left', duration: 0.5 });
+    const serialized = JSON.parse(JSON.stringify(state.transitions));
+    expect(serialized).toHaveLength(2);
+    expect(serialized[0].type).toBe('crossfade');
+    expect(serialized[1].type).toBe('wipe-left');
   });
 
   it('should build export settings with transition data', () => {
-    const { setTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'dissolve', duration: 1.5 });
+    const { addTransition } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'dissolve',
+      duration: 1.5,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
 
     const state = useTimelineStore.getState();
     // ExportDialog が構築するのと同じ形式
@@ -100,25 +129,30 @@ describe('transition export data', () => {
       fps: 30,
       outputPath: '/tmp/test.mp4',
       tracks: state.tracks,
+      transitions: state.transitions,
       totalDuration: 15,
     };
 
     const serialized = JSON.parse(JSON.stringify(exportSettings));
-    const videoTrack = serialized.tracks.find((t: { type: string }) => t.type === 'video');
-    const clip2 = videoTrack.clips.find((c: { id: string }) => c.id === 'clip-2');
-    expect(clip2.transition).toEqual({ type: 'dissolve', duration: 1.5 });
+    expect(serialized.transitions[0]).toMatchObject({ type: 'dissolve', duration: 1.5, inClipId: 'clip-2' });
   });
 
   it('should handle all transition types for export', () => {
-    const { setTransition } = useTimelineStore.getState();
+    const { addTransition, removeTransitionById } = useTimelineStore.getState();
     const types = ['crossfade', 'dissolve', 'wipe-left', 'wipe-right', 'wipe-up', 'wipe-down'] as const;
 
     for (const type of types) {
-      setTransition('video-1', 'clip-2', { type, duration: 1.0 });
-      const state = useTimelineStore.getState();
-      const track = state.tracks.find(t => t.id === 'video-1')!;
-      const clip2 = track.clips.find(c => c.id === 'clip-2')!;
-      expect(clip2.transition!.type).toBe(type);
+      addTransition({
+        id: 'transition-clip-1-clip-2',
+        type,
+        duration: 1.0,
+        outTrackId: 'video-1',
+        outClipId: 'clip-1',
+        inTrackId: 'video-1',
+        inClipId: 'clip-2',
+      });
+      expect(useTimelineStore.getState().transitions[0].type).toBe(type);
+      removeTransitionById('transition-clip-1-clip-2');
     }
   });
 });

--- a/src/test/transitionMigration.test.ts
+++ b/src/test/transitionMigration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Track, TimelineTransition } from '../store/timelineStore';
+import type { ClipTransition, Track, TimelineTransition } from '../store/timelineStore';
 import {
   migrateClipTransitionsToTimeline,
   timelineTransitionsToClipTransitions,
@@ -17,6 +17,13 @@ function createVideoTrack(id: string, clips: Track['clips']): Track {
   };
 }
 
+function withLegacyTransition<T extends Track['clips'][number]>(
+  clip: T,
+  transition: ClipTransition,
+): T & { transition: ClipTransition } {
+  return { ...clip, transition };
+}
+
 describe('transitionMigration', () => {
   it('migrates same-track adjacent clip transitions into timeline transitions', () => {
     const tracks: Track[] = [
@@ -30,7 +37,7 @@ describe('transitionMigration', () => {
           sourceStartTime: 0,
           sourceEndTime: 5,
         },
-        {
+        withLegacyTransition({
           id: 'clip-2',
           name: 'Clip 2',
           startTime: 5,
@@ -38,8 +45,7 @@ describe('transitionMigration', () => {
           filePath: 'b.mp4',
           sourceStartTime: 0,
           sourceEndTime: 5,
-          transition: { type: 'crossfade', duration: 1 },
-        },
+        }, { type: 'crossfade', duration: 1 }),
       ]),
     ];
 
@@ -68,7 +74,7 @@ describe('transitionMigration', () => {
           sourceStartTime: 0,
           sourceEndTime: 5,
         },
-        {
+        withLegacyTransition({
           id: 'clip-2',
           name: 'Clip 2',
           startTime: 5,
@@ -76,8 +82,7 @@ describe('transitionMigration', () => {
           filePath: 'b.mp4',
           sourceStartTime: 0,
           sourceEndTime: 5,
-          transition: { type: 'wipe-left', duration: 0.5 },
-        },
+        }, { type: 'wipe-left', duration: 0.5 }),
       ]),
       createVideoTrack('video-2', [
         {
@@ -89,7 +94,7 @@ describe('transitionMigration', () => {
           sourceStartTime: 0,
           sourceEndTime: 3,
         },
-        {
+        withLegacyTransition({
           id: 'clip-4',
           name: 'Clip 4',
           startTime: 3,
@@ -97,8 +102,7 @@ describe('transitionMigration', () => {
           filePath: 'd.mp4',
           sourceStartTime: 0,
           sourceEndTime: 4,
-          transition: { type: 'dissolve', duration: 0.75 },
-        },
+        }, { type: 'dissolve', duration: 0.75 }),
       ]),
     ];
 
@@ -127,7 +131,7 @@ describe('transitionMigration', () => {
   it('ignores clips without transition and first clips with transition but no previous clip', () => {
     const tracks: Track[] = [
       createVideoTrack('video-1', [
-        {
+        withLegacyTransition({
           id: 'clip-1',
           name: 'Clip 1',
           startTime: 0,
@@ -135,8 +139,7 @@ describe('transitionMigration', () => {
           filePath: 'a.mp4',
           sourceStartTime: 0,
           sourceEndTime: 5,
-          transition: { type: 'crossfade', duration: 1 },
-        },
+        }, { type: 'crossfade', duration: 1 }),
         {
           id: 'clip-2',
           name: 'Clip 2',
@@ -189,9 +192,9 @@ describe('transitionMigration', () => {
 
     const migrated = timelineTransitionsToClipTransitions(transitions, tracks);
 
-    expect(migrated[0].clips[0].transition).toBeUndefined();
-    expect(migrated[0].clips[1].transition).toEqual({ type: 'crossfade', duration: 1 });
-    expect(tracks[0].clips[1].transition).toBeUndefined();
+    expect((migrated[0].clips[0] as { transition?: ClipTransition }).transition).toBeUndefined();
+    expect((migrated[0].clips[1] as { transition?: ClipTransition }).transition).toEqual({ type: 'crossfade', duration: 1 });
+    expect((tracks[0].clips[1] as { transition?: ClipTransition }).transition).toBeUndefined();
   });
 
   it('drops cross-track transitions on reverse conversion', () => {
@@ -232,8 +235,8 @@ describe('transitionMigration', () => {
       },
     ], tracks);
 
-    expect(migrated[0].clips[0].transition).toBeUndefined();
-    expect(migrated[1].clips[0].transition).toBeUndefined();
+    expect((migrated[0].clips[0] as { transition?: ClipTransition }).transition).toBeUndefined();
+    expect((migrated[1].clips[0] as { transition?: ClipTransition }).transition).toBeUndefined();
   });
 
   it('handles empty tracks and clips without error', () => {

--- a/src/test/transitionPlayback.test.ts
+++ b/src/test/transitionPlayback.test.ts
@@ -8,34 +8,31 @@ import { useTimelineStore, type TransitionType } from '../store/timelineStore';
 
 // findTransitionAtTime のロジックを再現
 function findTransitionAtTime(time: number) {
-  const tracks = useTimelineStore.getState().tracks;
-  for (const track of tracks) {
-    if (track.type !== 'video') continue;
-    for (const clip of track.clips) {
-      if (!clip.transition) continue;
-      const overlapStart = clip.startTime - clip.transition.duration;
-      const overlapEnd = clip.startTime;
-      if (time >= overlapStart && time < overlapEnd) {
-        // outgoing clip を探す
-        let outgoing = null;
-        for (const t of tracks) {
-          if (t.type !== 'video') continue;
-          for (const c of t.clips) {
-            if (time >= c.startTime && time < c.startTime + c.duration) {
-              outgoing = c;
-              break;
-            }
+  const { tracks, transitions } = useTimelineStore.getState();
+  for (const transition of transitions) {
+    const incomingClip = tracks.find((track) => track.id === transition.inTrackId)?.clips.find((clip) => clip.id === transition.inClipId);
+    if (!incomingClip) continue;
+    const overlapStart = incomingClip.startTime - transition.duration;
+    const overlapEnd = incomingClip.startTime;
+    if (time >= overlapStart && time < overlapEnd) {
+      let outgoing = null;
+      for (const t of tracks) {
+        if (t.type !== 'video') continue;
+        for (const c of t.clips) {
+          if (time >= c.startTime && time < c.startTime + c.duration) {
+            outgoing = c;
+            break;
           }
         }
-        if (!outgoing || outgoing.id === clip.id) continue;
-        const progress = (time - overlapStart) / clip.transition.duration;
-        return {
-          outgoingClip: outgoing,
-          incomingClip: clip,
-          progress,
-          transitionType: clip.transition.type,
-        };
       }
+      if (!outgoing || outgoing.id === incomingClip.id) continue;
+      const progress = (time - overlapStart) / transition.duration;
+      return {
+        outgoingClip: outgoing,
+        incomingClip,
+        progress,
+        transitionType: transition.type,
+      };
     }
   }
   return null;
@@ -82,6 +79,7 @@ describe('transition playback logic', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,
@@ -89,7 +87,7 @@ describe('transition playback logic', () => {
       pixelsPerSecond: 50,
     });
 
-    const { addTrack, addClip, setTransition } = useTimelineStore.getState();
+    const { addTrack, addClip, addTransition } = useTimelineStore.getState();
     addTrack({ id: 'video-1', type: 'video', name: 'Video 1', clips: [] });
     addClip('video-1', {
       id: 'clip-1',
@@ -109,7 +107,15 @@ describe('transition playback logic', () => {
       sourceStartTime: 0,
       sourceEndTime: 5,
     });
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
   });
 
   describe('findTransitionAtTime', () => {
@@ -142,8 +148,8 @@ describe('transition playback logic', () => {
     });
 
     it('should return null when no transition is set', () => {
-      const { removeTransition } = useTimelineStore.getState();
-      removeTransition('video-1', 'clip-2');
+      const { removeTransitionById } = useTimelineStore.getState();
+      removeTransitionById('transition-clip-1-clip-2');
       expect(findTransitionAtTime(4.5)).toBeNull();
     });
   });

--- a/src/test/transitionUI.test.ts
+++ b/src/test/transitionUI.test.ts
@@ -5,6 +5,7 @@ describe('transition UI integration', () => {
   beforeEach(() => {
     useTimelineStore.setState({
       tracks: [],
+      transitions: [],
       selectedClipId: null,
       selectedTrackId: null,
       currentTime: 0,
@@ -35,46 +36,67 @@ describe('transition UI integration', () => {
   });
 
   it('should add default crossfade transition via context menu action', () => {
-    const { setTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
+    const { addTransition } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
 
     const state = useTimelineStore.getState();
-    const track = state.tracks.find(t => t.id === 'video-1');
-    const clip2 = track!.clips.find(c => c.id === 'clip-2');
-    expect(clip2!.transition).toEqual({ type: 'crossfade', duration: 1.0 });
+    expect(state.transitions[0]).toMatchObject({ type: 'crossfade', duration: 1.0, inClipId: 'clip-2' });
   });
 
   it('should remove transition via context menu action', () => {
-    const { setTransition, removeTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
-    removeTransition('video-1', 'clip-2');
+    const { addTransition, removeTransitionById } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
+    removeTransitionById('transition-clip-1-clip-2');
 
-    const state = useTimelineStore.getState();
-    const track = state.tracks.find(t => t.id === 'video-1');
-    const clip2 = track!.clips.find(c => c.id === 'clip-2');
-    expect(clip2!.transition).toBeUndefined();
+    expect(useTimelineStore.getState().transitions).toEqual([]);
   });
 
   it('should change transition type', () => {
-    const { setTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
-    setTransition('video-1', 'clip-2', { type: 'dissolve', duration: 1.0 });
+    const { addTransition, updateTransition } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
+    updateTransition('transition-clip-1-clip-2', { type: 'dissolve' });
 
-    const state = useTimelineStore.getState();
-    const track = state.tracks.find(t => t.id === 'video-1');
-    const clip2 = track!.clips.find(c => c.id === 'clip-2');
-    expect(clip2!.transition!.type).toBe('dissolve');
+    expect(useTimelineStore.getState().transitions[0].type).toBe('dissolve');
   });
 
   it('should change transition duration', () => {
-    const { setTransition } = useTimelineStore.getState();
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 1.0 });
-    setTransition('video-1', 'clip-2', { type: 'crossfade', duration: 2.5 });
+    const { addTransition, updateTransition } = useTimelineStore.getState();
+    addTransition({
+      id: 'transition-clip-1-clip-2',
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: 'video-1',
+      outClipId: 'clip-1',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
+    updateTransition('transition-clip-1-clip-2', { duration: 2.5 });
 
-    const state = useTimelineStore.getState();
-    const track = state.tracks.find(t => t.id === 'video-1');
-    const clip2 = track!.clips.find(c => c.id === 'clip-2');
-    expect(clip2!.transition!.duration).toBe(2.5);
+    expect(useTimelineStore.getState().transitions[0].duration).toBe(2.5);
   });
 
   it('should identify first clip has no previous clip', () => {

--- a/src/utils/transitionMigration.ts
+++ b/src/utils/transitionMigration.ts
@@ -1,4 +1,7 @@
-import type { Clip, Track, TimelineTransition } from '../store/timelineStore';
+import type { ClipTransition, Track, TimelineTransition } from '../store/timelineStore';
+
+type LegacyClip = Track['clips'][number] & { transition?: ClipTransition };
+type LegacyTrack = Omit<Track, 'clips'> & { clips: LegacyClip[] };
 
 function cloneTracks(tracks: Track[]): Track[] {
   return tracks.map((track) => ({
@@ -11,14 +14,14 @@ function createTransitionId(outClipId: string, inClipId: string): string {
   return `transition-${outClipId}-${inClipId}`;
 }
 
-function sortClipsByStartTime(clips: Clip[]): Clip[] {
+function sortClipsByStartTime(clips: LegacyClip[]): LegacyClip[] {
   return [...clips].sort((a, b) => a.startTime - b.startTime);
 }
 
 export function migrateClipTransitionsToTimeline(tracks: Track[]): TimelineTransition[] {
   const transitions: TimelineTransition[] = [];
 
-  for (const track of tracks) {
+  for (const track of tracks as LegacyTrack[]) {
     const sortedClips = sortClipsByStartTime(track.clips);
 
     for (let i = 0; i < sortedClips.length; i += 1) {
@@ -47,7 +50,7 @@ export function timelineTransitionsToClipTransitions(
   transitions: TimelineTransition[],
   tracks: Track[],
 ): Track[] {
-  const clonedTracks = cloneTracks(tracks);
+  const clonedTracks = cloneTracks(tracks) as LegacyTrack[];
 
   for (const transition of transitions) {
     if (transition.outTrackId !== transition.inTrackId) {
@@ -64,10 +67,7 @@ export function timelineTransitionsToClipTransitions(
       continue;
     }
 
-    incomingClip.transition = {
-      type: transition.type,
-      duration: transition.duration,
-    };
+    incomingClip.transition = { type: transition.type, duration: transition.duration };
   }
 
   return clonedTracks;


### PR DESCRIPTION
## Summary
- 既存の `clip.transition` フィールドを廃止し、すべてのトランジション操作を `TimelineTransition` 独立エンティティ経由に統一
- Phase 1-D: ストアAPI移行（#196, #197, #198 の上に構築）

## 変更内容
- `clipSlice` から旧 `setTransition`/`removeTransition` を削除
- `Clip` 型から `transition` フィールドを削除
- UI コンポーネント（`ClipContextMenu`, `TransitionPopover`, `TransitionIndicator`, `Track`）を新 API に移行
- `useTransitionEffect` を `transitions` ストアベースに書き換え
- `usePlaybackLoop` のトランジション終了判定を `duration` ベースに修正
- `transitionMigration` を `LegacyClip` 型で旧形式を明示的に扱うよう変更
- 既存テスト全件を新 API に書き換え

## テスト計画
- [x] `npm run test` で全678テストがパスすること
- [x] `npm run lint` でエラーがないこと
- [x] `npm run build` でビルドが通ること

手動打鍵:
- [ ] トランジションの追加（右クリック → トランジションを追加）が動作すること
- [ ] トランジションインジケーターがタイムライン上に正しく表示されること
- [ ] トランジションのタイプ・duration 変更がポップオーバーから動作すること
- [ ] トランジションの削除が動作すること
- [ ] トランジション再生プレビューが従来通り動作すること
- [ ] Undo/Redo でトランジション操作が巻き戻せること

Closes #199