### PR TITLE
クロストラックトランジションの追加 UI（Issue #204）

### DIFF
--- a/src/components/Timeline/ClipContextMenu.tsx
+++ b/src/components/Timeline/ClipContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTimelineStore, Clip as ClipType, DEFAULT_EFFECTS, type TimelineTransition, type TransitionType } from '../../store/timelineStore';
 import { TransitionSubmenu } from './TransitionSubmenu';
@@ -37,7 +37,10 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
     state.transitions.find((transition) => transition.inClipId === clip.id && transition.inTrackId === trackId),
   );
   const hasTransition = !!incomingTransition;
-  const crossTrackCandidates = listCrossTrackTransitionCandidates(tracks, trackId, clip.id);
+  const crossTrackCandidates = useMemo(
+    () => listCrossTrackTransitionCandidates(tracks, trackId, clip.id),
+    [tracks, trackId, clip.id],
+  );
 
   const findPreviousClip = (): ClipType | null => {
     const track = useTimelineStore.getState().tracks.find((candidate) => candidate.id === trackId);
@@ -124,7 +127,7 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
 
   const handleSelectCrossTrackCandidate = (candidate: CrossTrackTransitionCandidate) => {
     const transition: TimelineTransition = {
-      id: `transition-${candidate.clipId}-${clip.id}`,
+      id: `transition-${candidate.trackId}-${candidate.clipId}-${trackId}-${clip.id}`,
       type: 'crossfade',
       duration: 1.0,
       outTrackId: candidate.trackId,

--- a/src/components/Timeline/ClipContextMenu.tsx
+++ b/src/components/Timeline/ClipContextMenu.tsx
@@ -2,7 +2,9 @@ import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTimelineStore, Clip as ClipType, DEFAULT_EFFECTS, type TimelineTransition, type TransitionType } from '../../store/timelineStore';
 import { TransitionSubmenu } from './TransitionSubmenu';
+import { CrossTrackTransitionSubmenu } from './CrossTrackTransitionSubmenu';
 import { clampMenuPosition } from './clipUtils';
+import { listCrossTrackTransitionCandidates, type CrossTrackTransitionCandidate } from './crossTrackTransitionUtils';
 
 interface ClipContextMenuProps {
   clip: ClipType;
@@ -27,12 +29,15 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
   const [menuPos, setMenuPos] = useState(position);
   const [visible, setVisible] = useState(false);
   const [showTransitionSubmenu, setShowTransitionSubmenu] = useState(false);
+  const [showCrossTrackSubmenu, setShowCrossTrackSubmenu] = useState(false);
   const contextMenuRef = useRef<HTMLDivElement>(null);
+  const tracks = useTimelineStore((state) => state.tracks);
 
   const incomingTransition = useTimelineStore((state) =>
     state.transitions.find((transition) => transition.inClipId === clip.id && transition.inTrackId === trackId),
   );
   const hasTransition = !!incomingTransition;
+  const crossTrackCandidates = listCrossTrackTransitionCandidates(tracks, trackId, clip.id);
 
   const findPreviousClip = (): ClipType | null => {
     const track = useTimelineStore.getState().tracks.find((candidate) => candidate.id === trackId);
@@ -117,6 +122,21 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
     onClose();
   };
 
+  const handleSelectCrossTrackCandidate = (candidate: CrossTrackTransitionCandidate) => {
+    const transition: TimelineTransition = {
+      id: `transition-${candidate.clipId}-${clip.id}`,
+      type: 'crossfade',
+      duration: 1.0,
+      outTrackId: candidate.trackId,
+      outClipId: candidate.clipId,
+      inTrackId: trackId,
+      inClipId: clip.id,
+    };
+
+    addTransition(transition);
+    onClose();
+  };
+
   // コンテキストメニューが画面外にはみ出る場合、位置を自動補正
   useEffect(() => {
     if (!contextMenuRef.current) return;
@@ -175,6 +195,39 @@ export function ClipContextMenu({ clip, trackId, trackType, position, onClose }:
             🔄 {t('transition.add')} ▸
             {showTransitionSubmenu && (
               <TransitionSubmenu onSelectTransition={handleSelectTransition} />
+            )}
+          </div>
+        )}
+        {!hasTransition && trackType === 'video' && (
+          <div
+            className="context-menu-item context-menu-submenu-trigger"
+            role="menuitem"
+            aria-haspopup="menu"
+            aria-expanded={showCrossTrackSubmenu}
+            tabIndex={0}
+            onMouseEnter={() => setShowCrossTrackSubmenu(true)}
+            onMouseLeave={() => setShowCrossTrackSubmenu(false)}
+            onFocus={() => setShowCrossTrackSubmenu(true)}
+            onBlur={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget)) {
+                setShowCrossTrackSubmenu(false);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                setShowCrossTrackSubmenu(true);
+              } else if (e.key === 'Escape' || e.key === 'ArrowLeft') {
+                setShowCrossTrackSubmenu(false);
+              }
+            }}
+          >
+            🔀 他のトラックのクリップと... ▸
+            {showCrossTrackSubmenu && (
+              <CrossTrackTransitionSubmenu
+                candidates={crossTrackCandidates}
+                onSelectCandidate={handleSelectCrossTrackCandidate}
+              />
             )}
           </div>
         )}

--- a/src/components/Timeline/CrossTrackTransitionSubmenu.tsx
+++ b/src/components/Timeline/CrossTrackTransitionSubmenu.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+import type { CrossTrackTransitionCandidate } from './crossTrackTransitionUtils';
+
+interface CrossTrackTransitionSubmenuProps {
+  candidates: CrossTrackTransitionCandidate[];
+  onSelectCandidate: (candidate: CrossTrackTransitionCandidate) => void;
+}
+
+export function CrossTrackTransitionSubmenu({
+  candidates,
+  onSelectCandidate,
+}: CrossTrackTransitionSubmenuProps) {
+  const submenuRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<React.CSSProperties>({ visibility: 'hidden' });
+
+  useEffect(() => {
+    if (!submenuRef.current) return;
+    const rect = submenuRef.current.getBoundingClientRect();
+    const newStyle: React.CSSProperties = { visibility: 'visible' };
+
+    if (rect.bottom > window.innerHeight) {
+      const overflow = rect.bottom - window.innerHeight;
+      newStyle.top = `${-overflow}px`;
+    } else {
+      newStyle.top = '0';
+    }
+
+    if (rect.right > window.innerWidth) {
+      newStyle.left = 'auto';
+      newStyle.right = '100%';
+    } else {
+      newStyle.left = '100%';
+      newStyle.right = 'auto';
+    }
+
+    setStyle(newStyle);
+  }, []);
+
+  return (
+    <div ref={submenuRef} className="context-submenu" style={style}>
+      {candidates.length > 0 ? candidates.map((candidate) => (
+        <button
+          key={`${candidate.trackId}-${candidate.clipId}`}
+          className="context-menu-item"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelectCandidate(candidate);
+          }}
+        >
+          {candidate.trackName} / {candidate.clipName}
+        </button>
+      )) : (
+        <button className="context-menu-item" disabled>
+          候補なし
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/Timeline/Timeline.css
+++ b/src/components/Timeline/Timeline.css
@@ -500,6 +500,16 @@
   border-color: rgba(255, 165, 0, 0.9);
 }
 
+.transition-indicator-cross-track {
+  background: linear-gradient(90deg, rgba(74, 158, 255, 0.35), rgba(74, 158, 255, 0.18), rgba(74, 158, 255, 0.35));
+  border-color: rgba(74, 158, 255, 0.8);
+}
+
+.transition-indicator-cross-track:hover {
+  background: linear-gradient(90deg, rgba(74, 158, 255, 0.5), rgba(74, 158, 255, 0.28), rgba(74, 158, 255, 0.5));
+  border-color: rgba(74, 158, 255, 1);
+}
+
 .transition-icon {
   font-size: 1rem;
   color: #ffa500;

--- a/src/components/Timeline/Track.tsx
+++ b/src/components/Timeline/Track.tsx
@@ -34,7 +34,7 @@ function Track({ track }: TrackProps) {
   const pixelsPerSecond = useTimelineStore((s) => s.pixelsPerSecond);
   const allTransitions = useTimelineStore((s) => s.transitions);
   const transitions = useMemo(
-    () => allTransitions.filter((transition) => transition.inTrackId === track.id && transition.outTrackId === track.id),
+    () => allTransitions.filter((transition) => transition.inTrackId === track.id),
     [allTransitions, track.id],
   );
   const overlaps = useMemo(() => computeOverlaps(track.clips), [track.clips]);

--- a/src/components/Timeline/TransitionIndicator.tsx
+++ b/src/components/Timeline/TransitionIndicator.tsx
@@ -42,18 +42,20 @@ function TransitionIndicator({ transition, incomingClip }: TransitionIndicatorPr
     removeTransitionById(transition.id);
     setShowContextMenu(false);
   };
+  const isCrossTrack = transition.outTrackId !== transition.inTrackId;
 
   return (
     <>
       <div
         ref={indicatorRef}
-        className="transition-indicator"
+        className={`transition-indicator${isCrossTrack ? ' transition-indicator-cross-track' : ''}`}
+        data-cross-track={isCrossTrack ? 'true' : 'false'}
         style={{ left: `${left}px`, width: `${width}px` }}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
         title={t(TRANSITION_I18N_KEYS[transition.type])}
       >
-        <span className="transition-icon">◆</span>
+        <span className="transition-icon">{isCrossTrack ? '↕' : '◆'}</span>
         <span className="transition-label">
           {t(TRANSITION_I18N_KEYS[transition.type])}
         </span>

--- a/src/components/Timeline/crossTrackTransitionUtils.ts
+++ b/src/components/Timeline/crossTrackTransitionUtils.ts
@@ -1,0 +1,78 @@
+import type { Clip, Track } from '../../store/timelineStore';
+
+export const CROSS_TRACK_TRANSITION_EPSILON = 0.05;
+
+export interface CrossTrackTransitionCandidate {
+  trackId: string;
+  trackName: string;
+  clipId: string;
+  clipName: string;
+  startTime: number;
+  duration: number;
+}
+
+function clipEndTime(clip: Pick<Clip, 'startTime' | 'duration'>): number {
+  return clip.startTime + clip.duration;
+}
+
+export function canCreateCrossTrackTransition(
+  baseTrack: Pick<Track, 'type'>,
+  baseClip: Pick<Clip, 'id' | 'startTime' | 'duration'>,
+  candidateTrack: Pick<Track, 'id' | 'type'>,
+  candidateClip: Pick<Clip, 'id' | 'startTime' | 'duration'>,
+  epsilon = CROSS_TRACK_TRANSITION_EPSILON,
+): boolean {
+  if (baseTrack.type !== 'video' || candidateTrack.type !== 'video') {
+    return false;
+  }
+
+  if (candidateTrack.id === undefined || candidateClip.id === baseClip.id) {
+    return false;
+  }
+
+  const baseStart = baseClip.startTime;
+  const candidateStart = candidateClip.startTime;
+  const candidateEnd = clipEndTime(candidateClip);
+
+  return candidateStart <= baseStart + epsilon && candidateEnd >= baseStart - epsilon;
+}
+
+export function listCrossTrackTransitionCandidates(
+  tracks: Track[],
+  baseTrackId: string,
+  baseClipId: string,
+  epsilon = CROSS_TRACK_TRANSITION_EPSILON,
+): CrossTrackTransitionCandidate[] {
+  const baseTrack = tracks.find((track) => track.id === baseTrackId);
+  const baseClip = baseTrack?.clips.find((clip) => clip.id === baseClipId);
+
+  if (!baseTrack || !baseClip || baseTrack.type !== 'video') {
+    return [];
+  }
+
+  return tracks
+    .filter((track) => track.id !== baseTrackId && track.type === 'video')
+    .flatMap((track) =>
+      track.clips
+        .filter((clip) => canCreateCrossTrackTransition(baseTrack, baseClip, track, clip, epsilon))
+        .map((clip) => ({
+          trackId: track.id,
+          trackName: track.name,
+          clipId: clip.id,
+          clipName: clip.name,
+          startTime: clip.startTime,
+          duration: clip.duration,
+        })),
+    )
+    .sort((a, b) => {
+      const aDistance = Math.abs((a.startTime + a.duration) - baseClip.startTime);
+      const bDistance = Math.abs((b.startTime + b.duration) - baseClip.startTime);
+      if (aDistance !== bDistance) {
+        return aDistance - bDistance;
+      }
+      if (a.startTime !== b.startTime) {
+        return a.startTime - b.startTime;
+      }
+      return a.trackName.localeCompare(b.trackName);
+    });
+}

--- a/src/components/Timeline/crossTrackTransitionUtils.ts
+++ b/src/components/Timeline/crossTrackTransitionUtils.ts
@@ -16,7 +16,7 @@ function clipEndTime(clip: Pick<Clip, 'startTime' | 'duration'>): number {
 }
 
 export function canCreateCrossTrackTransition(
-  baseTrack: Pick<Track, 'type'>,
+  baseTrack: Pick<Track, 'id' | 'type'>,
   baseClip: Pick<Clip, 'id' | 'startTime' | 'duration'>,
   candidateTrack: Pick<Track, 'id' | 'type'>,
   candidateClip: Pick<Clip, 'id' | 'startTime' | 'duration'>,
@@ -26,7 +26,7 @@ export function canCreateCrossTrackTransition(
     return false;
   }
 
-  if (candidateTrack.id === undefined || candidateClip.id === baseClip.id) {
+  if (candidateTrack.id === baseTrack.id) {
     return false;
   }
 

--- a/src/test/crossTrackTransitionUtils.test.ts
+++ b/src/test/crossTrackTransitionUtils.test.ts
@@ -75,4 +75,26 @@ describe('crossTrackTransitionUtils', () => {
 
     expect(allowed).toBe(false);
   });
+
+  it('同一トラック同士はクロストラック候補にしない', () => {
+    const allowed = canCreateCrossTrackTransition(
+      makeTrack({ id: 'video-1', type: 'video' }),
+      { id: 'clip-1', startTime: 5, duration: 5 },
+      makeTrack({ id: 'video-1', type: 'video' }),
+      { id: 'clip-2', startTime: 2, duration: 3 },
+    );
+
+    expect(allowed).toBe(false);
+  });
+
+  it('別トラックなら同じ clip id でも候補にできる', () => {
+    const allowed = canCreateCrossTrackTransition(
+      makeTrack({ id: 'video-1', type: 'video' }),
+      { id: 'shared-clip', startTime: 5, duration: 5 },
+      makeTrack({ id: 'video-2', type: 'video' }),
+      { id: 'shared-clip', startTime: 2, duration: 3 },
+    );
+
+    expect(allowed).toBe(true);
+  });
 });

--- a/src/test/crossTrackTransitionUtils.test.ts
+++ b/src/test/crossTrackTransitionUtils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { Track } from '@/store/timelineStore';
+import {
+  canCreateCrossTrackTransition,
+  listCrossTrackTransitionCandidates,
+} from '@/components/Timeline/crossTrackTransitionUtils';
+
+function makeTrack(overrides: Partial<Track>): Track {
+  return {
+    id: 'track',
+    type: 'video',
+    name: 'Track',
+    clips: [],
+    volume: 1,
+    mute: false,
+    solo: false,
+    ...overrides,
+  };
+}
+
+describe('crossTrackTransitionUtils', () => {
+  it('他トラックの重なり/隣接クリップ候補を列挙する', () => {
+    const tracks: Track[] = [
+      makeTrack({
+        id: 'video-1',
+        name: 'Video 1',
+        clips: [
+          { id: 'clip-1', name: 'Clip 1', startTime: 0, duration: 5, filePath: 'a.mp4', sourceStartTime: 0, sourceEndTime: 5 },
+          { id: 'clip-2', name: 'Clip 2', startTime: 5, duration: 5, filePath: 'b.mp4', sourceStartTime: 0, sourceEndTime: 5 },
+        ],
+      }),
+      makeTrack({
+        id: 'video-2',
+        name: 'Video 2',
+        clips: [
+          { id: 'clip-a', name: 'Clip A', startTime: 2, duration: 3, filePath: 'c.mp4', sourceStartTime: 0, sourceEndTime: 3 },
+          { id: 'clip-b', name: 'Clip B', startTime: 4, duration: 1, filePath: 'd.mp4', sourceStartTime: 0, sourceEndTime: 1 },
+        ],
+      }),
+    ];
+
+    const candidates = listCrossTrackTransitionCandidates(tracks, 'video-1', 'clip-2');
+
+    expect(candidates.map((candidate) => candidate.clipId)).toEqual(['clip-a', 'clip-b']);
+  });
+
+  it('時間的に重なりも隣接もないクリップは候補に含めない', () => {
+    const tracks: Track[] = [
+      makeTrack({
+        id: 'video-1',
+        name: 'Video 1',
+        clips: [
+          { id: 'clip-2', name: 'Clip 2', startTime: 5, duration: 5, filePath: 'b.mp4', sourceStartTime: 0, sourceEndTime: 5 },
+        ],
+      }),
+      makeTrack({
+        id: 'video-2',
+        name: 'Video 2',
+        clips: [
+          { id: 'clip-c', name: 'Clip C', startTime: 6, duration: 2, filePath: 'e.mp4', sourceStartTime: 0, sourceEndTime: 2 },
+        ],
+      }),
+    ];
+
+    expect(listCrossTrackTransitionCandidates(tracks, 'video-1', 'clip-2')).toEqual([]);
+  });
+
+  it('audio トラックへの適用を禁止する', () => {
+    const allowed = canCreateCrossTrackTransition(
+      makeTrack({ id: 'video-1', type: 'video' }),
+      { id: 'clip-2', startTime: 5, duration: 5 },
+      makeTrack({ id: 'audio-1', type: 'audio' }),
+      { id: 'clip-a', startTime: 0, duration: 5 },
+    );
+
+    expect(allowed).toBe(false);
+  });
+});

--- a/src/test/timelineTransitionComponents.test.tsx
+++ b/src/test/timelineTransitionComponents.test.tsx
@@ -315,6 +315,7 @@ describe('TimelineTransition UI components', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Video 2 / Clip A' }));
 
     expect(useTimelineStore.getState().transitions[0]).toMatchObject({
+      id: 'transition-video-2-clip-a-video-1-clip-2',
       type: 'crossfade',
       duration: 1,
       outTrackId: 'video-2',

--- a/src/test/timelineTransitionComponents.test.tsx
+++ b/src/test/timelineTransitionComponents.test.tsx
@@ -48,6 +48,26 @@ describe('TimelineTransition UI components', () => {
       sourceStartTime: 0,
       sourceEndTime: 5,
     });
+    addTrack({ id: 'video-2', type: 'video', name: 'Video 2', clips: [] });
+    addClip('video-2', {
+      id: 'clip-a',
+      name: 'Clip A',
+      startTime: 2,
+      duration: 3,
+      filePath: 'c.mp4',
+      sourceStartTime: 0,
+      sourceEndTime: 3,
+    });
+    addTrack({ id: 'audio-1', type: 'audio', name: 'Audio 1', clips: [] });
+    addClip('audio-1', {
+      id: 'clip-audio',
+      name: 'Clip Audio',
+      startTime: 0,
+      duration: 5,
+      filePath: 'x.wav',
+      sourceStartTime: 0,
+      sourceEndTime: 5,
+    });
   });
 
   it('computeIndicatorLayout は TimelineTransition とクリップ情報から位置を計算する', () => {
@@ -135,7 +155,7 @@ describe('TimelineTransition UI components', () => {
   });
 
   it('ClipContextMenu から追加すると addTransition が反映される', () => {
-    const clip = useTimelineStore.getState().tracks[0].clips.find((candidate) => candidate.id === 'clip-2');
+    const clip = useTimelineStore.getState().tracks.find((track) => track.id === 'video-1')!.clips.find((candidate) => candidate.id === 'clip-2');
     render(
       <ClipContextMenu
         clip={clip!}
@@ -171,7 +191,7 @@ describe('TimelineTransition UI components', () => {
       loaded: true,
     });
 
-    const clip = useTimelineStore.getState().tracks[0].clips.find((candidate) => candidate.id === 'clip-2');
+    const clip = useTimelineStore.getState().tracks.find((track) => track.id === 'video-1')!.clips.find((candidate) => candidate.id === 'clip-2');
     render(
       <ClipContextMenu
         clip={clip!}
@@ -204,7 +224,7 @@ describe('TimelineTransition UI components', () => {
       inClipId: 'clip-2',
     });
 
-    const clip = useTimelineStore.getState().tracks[0].clips.find((candidate) => candidate.id === 'clip-2');
+    const clip = useTimelineStore.getState().tracks.find((track) => track.id === 'video-1')!.clips.find((candidate) => candidate.id === 'clip-2');
     render(
       <ClipContextMenu
         clip={clip!}
@@ -277,5 +297,65 @@ describe('TimelineTransition UI components', () => {
       type: 'wipe-up',
       duration: 2.3,
     });
+  });
+
+  it('ClipContextMenu からクロストラック候補を選ぶとストアに反映される', () => {
+    const clip = useTimelineStore.getState().tracks.find((track) => track.id === 'video-1')!.clips.find((candidate) => candidate.id === 'clip-2');
+    render(
+      <ClipContextMenu
+        clip={clip!}
+        trackId="video-1"
+        trackType="video"
+        position={{ x: 100, y: 100 }}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByText(/他のトラックのクリップと/));
+    fireEvent.click(screen.getByRole('button', { name: 'Video 2 / Clip A' }));
+
+    expect(useTimelineStore.getState().transitions[0]).toMatchObject({
+      type: 'crossfade',
+      duration: 1,
+      outTrackId: 'video-2',
+      outClipId: 'clip-a',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
+  });
+
+  it('Track はクロストラック transition を incoming track 側に表示する', () => {
+    useTimelineStore.getState().addTransition({
+      id: 'transition-cross-track',
+      type: 'crossfade',
+      duration: 1,
+      outTrackId: 'video-2',
+      outClipId: 'clip-a',
+      inTrackId: 'video-1',
+      inClipId: 'clip-2',
+    });
+
+    const track = useTimelineStore.getState().tracks.find((candidate) => candidate.id === 'video-1');
+    render(<Track track={track!} />);
+
+    const indicator = document.querySelector('.transition-indicator') as HTMLElement;
+    expect(indicator.dataset.crossTrack).toBe('true');
+    expect(indicator.className).toContain('transition-indicator-cross-track');
+    expect(indicator.style.left).toBe('225px');
+  });
+
+  it('audio トラックではクロストラック追加 UI を表示しない', () => {
+    const clip = useTimelineStore.getState().tracks.find((track) => track.id === 'audio-1')!.clips[0];
+    render(
+      <ClipContextMenu
+        clip={clip}
+        trackId="audio-1"
+        trackType="audio"
+        position={{ x: 100, y: 100 }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/他のトラックのクリップと/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- `crossTrackTransitionUtils.ts` を新規作成: 他トラックの時間的に重なる/隣接するクリップを候補として検出するロジック
- `CrossTrackTransitionSubmenu.tsx` を新規作成: 候補クリップをサブメニューで選択する UI
- `ClipContextMenu.tsx` にクロストラックトランジション追加メニューを統合
- `TransitionIndicator` にクロストラック表示スタイルを追加
- ユニットテスト: 候補列挙、非重複クリップ除外、audio トラック禁止、コンポーネントテスト

## Test plan
- [x] `npm run lint` パス
- [x] `npm run test` 全695テストパス
- [ ] 手打鍵: 複数ビデオトラックで重なるクリップを配置し、右クリック → クロストラックトランジション追加で候補が表示されること
- [ ] 手打鍵: 候補選択でトランジションがストアに追加されること
- [ ] 手打鍵: audio トラックのクリップにはクロストラックメニューが表示されないこと

Closes #204