### PR TITLE
クロストラックトランジションのプレビュー再生（Issue #205）

### DIFF
--- a/src/components/VideoPreview/usePlaybackLoop.ts
+++ b/src/components/VideoPreview/usePlaybackLoop.ts
@@ -70,6 +70,19 @@ interface TransitionPlaybackPlan {
   shouldSwitchIncoming: boolean;
 }
 
+interface ShouldResyncTransitionVideoParams {
+  currentVideoTime: number;
+  expectedSourceTime: number;
+  paused: boolean;
+}
+
+interface ShouldResyncActiveVideoParams {
+  currentVideoTime: number;
+  expectedSourceTime: number;
+  loadedUrlMatches: boolean;
+  isLoading: boolean;
+}
+
 export function getPlaybackTimelineTime({
   previousTimelineTime,
   clipStartTime,
@@ -121,6 +134,26 @@ export function shouldCleanupTransitionPlayback(
   transition: TransitionInfo | null,
 ): boolean {
   return wasInTransition && transition === null;
+}
+
+export function shouldResyncTransitionVideo({
+  currentVideoTime,
+  expectedSourceTime,
+  paused,
+}: ShouldResyncTransitionVideoParams): boolean {
+  return paused || Math.abs(currentVideoTime - expectedSourceTime) > 0.1;
+}
+
+export function shouldResyncActiveVideo({
+  currentVideoTime,
+  expectedSourceTime,
+  loadedUrlMatches,
+  isLoading,
+}: ShouldResyncActiveVideoParams): boolean {
+  if (isLoading || !loadedUrlMatches) {
+    return false;
+  }
+  return Math.abs(currentVideoTime - expectedSourceTime) > 0.1;
 }
 
 export const usePlaybackLoop = ({
@@ -221,7 +254,17 @@ export const usePlaybackLoop = ({
         }
 
         // incoming clip → transitionVideoRef
-        if (playbackPlan.shouldSwitchIncoming && playbackPlan.incomingUrl) {
+        if (
+          playbackPlan.incomingUrl &&
+          (
+            playbackPlan.shouldSwitchIncoming ||
+            shouldResyncTransitionVideo({
+              currentVideoTime: transitionVideoRef.current.currentTime,
+              expectedSourceTime: playbackPlan.incomingSourceTime,
+              paused: transitionVideoRef.current.paused,
+            })
+          )
+        ) {
           switchTransitionVideo(playbackPlan.incomingUrl, playbackPlan.incomingSourceTime);
         }
 
@@ -263,8 +306,19 @@ export const usePlaybackLoop = ({
         // incoming clip に videoRef を切り替え
         if (clip) {
           const url = useVideoPreviewStore.getState().videoUrls[clip.filePath];
-          if (url && url !== loadedVideoUrl.current) {
-            const sourceTime = clip.sourceStartTime + (currentTimeRef.current - clip.startTime);
+          const sourceTime = clip.sourceStartTime + (currentTimeRef.current - clip.startTime);
+          if (
+            url &&
+            (
+              url !== loadedVideoUrl.current ||
+              shouldResyncActiveVideo({
+                currentVideoTime: videoRef.current?.currentTime ?? 0,
+                expectedSourceTime: sourceTime,
+                loadedUrlMatches: url === loadedVideoUrl.current,
+                isLoading: isLoadingVideoRef.current,
+              })
+            )
+          ) {
             switchVideo(url, sourceTime, true);
           }
         }

--- a/src/components/VideoPreview/usePlaybackLoop.ts
+++ b/src/components/VideoPreview/usePlaybackLoop.ts
@@ -51,6 +51,25 @@ interface PlaybackTimelineTimeParams {
   videoSourceTime: number;
 }
 
+interface TransitionPlaybackPlanParams {
+  transition: TransitionInfo;
+  currentTime: number;
+  videoUrls: Record<string, string>;
+  loadedOutgoingUrl: string | null;
+  loadedIncomingUrl: string | null;
+  isLoadingOutgoing: boolean;
+  isLoadingIncoming: boolean;
+}
+
+interface TransitionPlaybackPlan {
+  outgoingUrl: string | null;
+  incomingUrl: string | null;
+  outgoingSourceTime: number;
+  incomingSourceTime: number;
+  shouldSwitchOutgoing: boolean;
+  shouldSwitchIncoming: boolean;
+}
+
 export function getPlaybackTimelineTime({
   previousTimelineTime,
   clipStartTime,
@@ -60,6 +79,48 @@ export function getPlaybackTimelineTime({
   const relativeTime = videoSourceTime - clipSourceStartTime;
   const timelineTime = clipStartTime + relativeTime;
   return getMonotonicPlaybackTime(previousTimelineTime, timelineTime);
+}
+
+export function getTransitionPlaybackPlan({
+  transition,
+  currentTime,
+  videoUrls,
+  loadedOutgoingUrl,
+  loadedIncomingUrl,
+  isLoadingOutgoing,
+  isLoadingIncoming,
+}: TransitionPlaybackPlanParams): TransitionPlaybackPlan {
+  const { outgoingClip, incomingClip, duration } = transition;
+  const outgoingUrl = videoUrls[outgoingClip.filePath] ?? null;
+  const incomingUrl = videoUrls[incomingClip.filePath] ?? null;
+  const overlapStartTime = incomingClip.startTime - duration;
+
+  const outgoingSourceTime =
+    outgoingClip.sourceStartTime + (currentTime - outgoingClip.startTime);
+  const incomingSourceTime =
+    incomingClip.sourceStartTime + (currentTime - overlapStartTime);
+
+  return {
+    outgoingUrl,
+    incomingUrl,
+    outgoingSourceTime,
+    incomingSourceTime,
+    shouldSwitchOutgoing:
+      Boolean(outgoingUrl) &&
+      outgoingUrl !== loadedOutgoingUrl &&
+      !isLoadingOutgoing,
+    shouldSwitchIncoming:
+      Boolean(incomingUrl) &&
+      incomingUrl !== loadedIncomingUrl &&
+      !isLoadingIncoming,
+  };
+}
+
+export function shouldCleanupTransitionPlayback(
+  wasInTransition: boolean,
+  transition: TransitionInfo | null,
+): boolean {
+  return wasInTransition && transition === null;
 }
 
 export const usePlaybackLoop = ({
@@ -142,28 +203,26 @@ export const usePlaybackLoop = ({
       const transition = findTransitionAtTime(currentTimeRef.current);
       if (transition && transitionVideoRef.current) {
         isInTransitionRef.current = true;
-        const { outgoingClip, incomingClip, progress, transitionType } = transition;
+        const { progress, transitionType } = transition;
         const urls = useVideoPreviewStore.getState().videoUrls;
+        const playbackPlan = getTransitionPlaybackPlan({
+          transition,
+          currentTime: currentTimeRef.current,
+          videoUrls: urls,
+          loadedOutgoingUrl: loadedVideoUrl.current,
+          loadedIncomingUrl: loadedTransitionVideoUrl.current,
+          isLoadingOutgoing: isLoadingVideoRef.current,
+          isLoadingIncoming: isLoadingTransitionVideoRef.current,
+        });
 
         // outgoing clip → videoRef
-        const outUrl = urls[outgoingClip.filePath];
-        if (outUrl && outUrl !== loadedVideoUrl.current && !isLoadingVideoRef.current) {
-          const srcTime =
-            outgoingClip.sourceStartTime + (currentTimeRef.current - outgoingClip.startTime);
-          switchVideo(outUrl, srcTime, true);
+        if (playbackPlan.shouldSwitchOutgoing && playbackPlan.outgoingUrl) {
+          switchVideo(playbackPlan.outgoingUrl, playbackPlan.outgoingSourceTime, true);
         }
 
         // incoming clip → transitionVideoRef
-        const inUrl = urls[incomingClip.filePath];
-        const incomingSourceTime =
-          incomingClip.sourceStartTime +
-          (currentTimeRef.current - (incomingClip.startTime - transition.duration));
-        if (
-          inUrl &&
-          inUrl !== loadedTransitionVideoUrl.current &&
-          !isLoadingTransitionVideoRef.current
-        ) {
-          switchTransitionVideo(inUrl, incomingSourceTime);
+        if (playbackPlan.shouldSwitchIncoming && playbackPlan.incomingUrl) {
+          switchTransitionVideo(playbackPlan.incomingUrl, playbackPlan.incomingSourceTime);
         }
 
         // CSS スタイルを直接更新（レンダー不要）
@@ -189,7 +248,7 @@ export const usePlaybackLoop = ({
       }
 
       // トランジション終了時のクリーンアップ
-      if (isInTransitionRef.current) {
+      if (shouldCleanupTransitionPlayback(isInTransitionRef.current, transition)) {
         isInTransitionRef.current = false;
         if (videoRef.current) {
           videoRef.current.style.opacity = '1';

--- a/src/test/playbackLoop.test.ts
+++ b/src/test/playbackLoop.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getTransitionPlaybackPlan,
   getMonotonicPlaybackTime,
   getPlaybackTimelineTime,
+  shouldCleanupTransitionPlayback,
 } from '../components/VideoPreview/usePlaybackLoop';
+import type { TransitionInfo } from '../components/VideoPreview/useTransitionEffect';
 
 describe('getMonotonicPlaybackTime', () => {
   it('keeps playback monotonic when decoder reports an earlier time', () => {
@@ -35,5 +38,134 @@ describe('getPlaybackTimelineTime', () => {
         videoSourceTime: 0.08,
       }),
     ).toBe(5.08);
+  });
+});
+
+describe('getTransitionPlaybackPlan', () => {
+  const transition: TransitionInfo = {
+    outgoingClip: {
+      id: 'clip-1',
+      name: 'Clip 1',
+      startTime: 0,
+      duration: 5,
+      filePath: 'a.mp4',
+      sourceStartTime: 10,
+      sourceEndTime: 15,
+    },
+    incomingClip: {
+      id: 'clip-2',
+      name: 'Clip 2',
+      startTime: 5,
+      duration: 5,
+      filePath: 'b.mp4',
+      sourceStartTime: 20,
+      sourceEndTime: 25,
+    },
+    outTrackId: 'video-1',
+    inTrackId: 'video-2',
+    progress: 0.5,
+    transitionType: 'crossfade',
+    duration: 1,
+  };
+
+  it('computes outgoing and incoming source times for cross-track playback', () => {
+    expect(
+      getTransitionPlaybackPlan({
+        transition,
+        currentTime: 4.5,
+        videoUrls: {
+          'a.mp4': 'blob:outgoing',
+          'b.mp4': 'blob:incoming',
+        },
+        loadedOutgoingUrl: null,
+        loadedIncomingUrl: null,
+        isLoadingOutgoing: false,
+        isLoadingIncoming: false,
+      }),
+    ).toMatchObject({
+      outgoingUrl: 'blob:outgoing',
+      incomingUrl: 'blob:incoming',
+      outgoingSourceTime: 14.5,
+      incomingSourceTime: 20.5,
+      shouldSwitchOutgoing: true,
+      shouldSwitchIncoming: true,
+    });
+  });
+
+  it('skips switching when both transition videos are already loaded', () => {
+    expect(
+      getTransitionPlaybackPlan({
+        transition,
+        currentTime: 4.5,
+        videoUrls: {
+          'a.mp4': 'blob:outgoing',
+          'b.mp4': 'blob:incoming',
+        },
+        loadedOutgoingUrl: 'blob:outgoing',
+        loadedIncomingUrl: 'blob:incoming',
+        isLoadingOutgoing: false,
+        isLoadingIncoming: false,
+      }),
+    ).toMatchObject({
+      shouldSwitchOutgoing: false,
+      shouldSwitchIncoming: false,
+    });
+  });
+
+  it('avoids switching while a transition video is still loading', () => {
+    expect(
+      getTransitionPlaybackPlan({
+        transition,
+        currentTime: 4.5,
+        videoUrls: {
+          'a.mp4': 'blob:outgoing',
+          'b.mp4': 'blob:incoming',
+        },
+        loadedOutgoingUrl: null,
+        loadedIncomingUrl: null,
+        isLoadingOutgoing: true,
+        isLoadingIncoming: true,
+      }),
+    ).toMatchObject({
+      shouldSwitchOutgoing: false,
+      shouldSwitchIncoming: false,
+    });
+  });
+});
+
+describe('shouldCleanupTransitionPlayback', () => {
+  it('cleans up after leaving a transition window', () => {
+    expect(shouldCleanupTransitionPlayback(true, null)).toBe(true);
+  });
+
+  it('keeps transition state while a transition is still active', () => {
+    const activeTransition: TransitionInfo = {
+      outgoingClip: {
+        id: 'clip-1',
+        name: 'Clip 1',
+        startTime: 0,
+        duration: 5,
+        filePath: 'a.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      },
+      incomingClip: {
+        id: 'clip-2',
+        name: 'Clip 2',
+        startTime: 5,
+        duration: 5,
+        filePath: 'b.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      },
+      outTrackId: 'video-1',
+      inTrackId: 'video-2',
+      progress: 0.25,
+      transitionType: 'wipe-left',
+      duration: 1,
+    };
+
+    expect(shouldCleanupTransitionPlayback(true, activeTransition)).toBe(false);
+    expect(shouldCleanupTransitionPlayback(false, null)).toBe(false);
   });
 });

--- a/src/test/playbackLoop.test.ts
+++ b/src/test/playbackLoop.test.ts
@@ -3,6 +3,8 @@ import {
   getTransitionPlaybackPlan,
   getMonotonicPlaybackTime,
   getPlaybackTimelineTime,
+  shouldResyncActiveVideo,
+  shouldResyncTransitionVideo,
   shouldCleanupTransitionPlayback,
 } from '../components/VideoPreview/usePlaybackLoop';
 import type { TransitionInfo } from '../components/VideoPreview/useTransitionEffect';
@@ -167,5 +169,51 @@ describe('shouldCleanupTransitionPlayback', () => {
 
     expect(shouldCleanupTransitionPlayback(true, activeTransition)).toBe(false);
     expect(shouldCleanupTransitionPlayback(false, null)).toBe(false);
+  });
+});
+
+describe('shouldResyncTransitionVideo', () => {
+  it('restarts a paused transition video even when the URL is unchanged', () => {
+    expect(
+      shouldResyncTransitionVideo({
+        currentVideoTime: 20.5,
+        expectedSourceTime: 20.5,
+        paused: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('resyncs when the transition video drifts from the expected source time', () => {
+    expect(
+      shouldResyncTransitionVideo({
+        currentVideoTime: 19.9,
+        expectedSourceTime: 20.5,
+        paused: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('shouldResyncActiveVideo', () => {
+  it('resyncs the active video after cleanup when the same URL points at a different range', () => {
+    expect(
+      shouldResyncActiveVideo({
+        currentVideoTime: 1.2,
+        expectedSourceTime: 3,
+        loadedUrlMatches: true,
+        isLoading: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not force a resync while the active video is still loading', () => {
+    expect(
+      shouldResyncActiveVideo({
+        currentVideoTime: 1.2,
+        expectedSourceTime: 3,
+        loadedUrlMatches: true,
+        isLoading: true,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- `usePlaybackLoop.ts` にクロストラックトランジションのプレビュー描画ロジックを追加
- 異なるトラック間のトランジション（crossfade/dissolve/wipe 等）がプレビュー再生中に正しく描画されるように対応
- `playbackLoop.test.ts` にクロストラック再生関連のテストを追加

## Test plan
- [x] `npm run lint` パス
- [x] `npm run test` 全702テストパス
- [ ] 手打鍵: 異なるトラックのクリップ間にトランジションを設定し、プレビュー再生でトランジション効果が表示されること
- [ ] 手打鍵: 同一トラック内のトランジションが従来通り動作すること

Closes #205