### PR TITLE
generateId ユーティリティの追加

### DIFF
--- a/src/test/idGenerator.test.ts
+++ b/src/test/idGenerator.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { generateId } from '../utils/idGenerator';
+
+describe('generateId', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('指定したprefixで始まるIDを生成する', () => {
+    const id = generateId('clip');
+    expect(id.startsWith('clip-')).toBe(true);
+  });
+
+  it('Date.now と Math.random を使って決定的なIDを生成する', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000000);
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789);
+
+    const id = generateId('test');
+    expect(id).toBe('test-1000000-4fzzzx');
+  });
+
+  it('同じ入力で同じIDを返す（参照透過性）', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(9999);
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const id1 = generateId('clip');
+    const id2 = generateId('clip');
+    expect(id1).toBe(id2);
+  });
+
+  it('異なるprefixで異なるIDを返す', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+    vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    const id1 = generateId('clip');
+    const id2 = generateId('track');
+    expect(id1).not.toBe(id2);
+    expect(id1.startsWith('clip-')).toBe(true);
+    expect(id2.startsWith('track-')).toBe(true);
+  });
+});

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -1,0 +1,9 @@
+/**
+ * ユニークID生成ユーティリティ
+ *
+ * Date.now() と Math.random() を使用してユニークなIDを生成する。
+ * テスト時は Date.now / Math.random をモックすることで決定的にテスト可能。
+ */
+export function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}


### PR DESCRIPTION
## 概要
コードベース全体で散在する `Date.now()` + `Math.random()` による ID 生成を共通化するためのユーティリティ関数を追加。

## 変更内容
- `src/utils/idGenerator.ts`: `generateId(prefix)` 関数を新規作成
- `src/test/idGenerator.test.ts`: Date.now/Math.random をモックした決定的テスト4件を追加

## 背景
参照透過性改善シリーズの第1弾。後続PRでこの `generateId` を各ストア・ユーティリティに導入していく。

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run test` パス
- [x] `npm run build` パス