### PR TITLE
subtitlesToTrack の参照透過性を改善

### DIFF
--- a/src/test/subtitles.test.ts
+++ b/src/test/subtitles.test.ts
@@ -63,6 +63,61 @@ describe('subtitlesToTrack', () => {
     expect(track.clips).toHaveLength(0);
     expect(track.type).toBe('text');
   });
+
+  it('startTime >= endTime の場合 duration が 0 以下になる', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const zeroEntries: SubtitleEntry[] = [
+      { startTime: 5, endTime: 5, text: 'Zero duration' },
+      { startTime: 10, endTime: 8, text: 'Negative duration' },
+    ];
+    const track = subtitlesToTrack(zeroEntries, 'Edge', idGen);
+
+    expect(track.clips[0].duration).toBe(0);
+    expect(track.clips[1].duration).toBe(-2);
+  });
+
+  it('20文字を超えるテキストはクリップ名が切り詰められる', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const longTextEntries: SubtitleEntry[] = [
+      { startTime: 0, endTime: 1, text: '12345678901234567890EXTRA' },
+      { startTime: 1, endTime: 2, text: 'short' },
+    ];
+    const track = subtitlesToTrack(longTextEntries, 'Sub', idGen);
+
+    expect(track.clips[0].name).toBe('12345678901234567890');
+    expect(track.clips[0].name).toHaveLength(20);
+    expect(track.clips[1].name).toBe('short');
+  });
+
+  it('entry.style がある場合 textProperties にマージされる', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const styledEntries: SubtitleEntry[] = [
+      { startTime: 0, endTime: 1, text: 'Styled', style: { fontSize: 48, fontColor: '#ff0000' } },
+    ];
+    const track = subtitlesToTrack(styledEntries, 'Sub', idGen);
+
+    expect(track.clips[0].textProperties?.fontSize).toBe(48);
+    expect(track.clips[0].textProperties?.fontColor).toBe('#ff0000');
+    expect(track.clips[0].textProperties?.text).toBe('Styled');
+  });
+
+  it('subtitlesToTrack → trackToSubtitles のラウンドトリップ', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const original: SubtitleEntry[] = [
+      { startTime: 0, endTime: 2, text: 'First' },
+      { startTime: 3, endTime: 5.5, text: 'Second' },
+    ];
+    const track = subtitlesToTrack(original, 'Sub', idGen);
+    const result = trackToSubtitles(track);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].startTime).toBe(0);
+    expect(result[0].endTime).toBe(2);
+    expect(result[0].text).toBe('First');
+    expect(result[1].startTime).toBe(3);
+    expect(result[1].endTime).toBe(5.5);
+    expect(result[1].text).toBe('Second');
+  });
 });
 
 describe('trackToSubtitles', () => {

--- a/src/test/subtitles.test.ts
+++ b/src/test/subtitles.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSRT,
+  exportSRT,
+  parseASS,
+  exportASS,
+  subtitlesToTrack,
+  trackToSubtitles,
+} from '../utils/subtitles';
+import type { SubtitleEntry } from '../utils/subtitles';
+
+describe('subtitlesToTrack', () => {
+  const entries: SubtitleEntry[] = [
+    { startTime: 0, endTime: 2, text: 'Hello' },
+    { startTime: 3, endTime: 5, text: 'World' },
+  ];
+
+  it('固定IDジェネレータを渡すと決定的なIDを生成する', () => {
+    let counter = 0;
+    const idGen = (prefix: string) => `${prefix}-fixed-${counter++}`;
+
+    const track = subtitlesToTrack(entries, 'Test', idGen);
+
+    expect(track.id).toBe('track-text-fixed-2');
+    expect(track.clips[0].id).toBe('text-fixed-0');
+    expect(track.clips[1].id).toBe('text-fixed-1');
+  });
+
+  it('IDジェネレータを省略してもトラックが生成される', () => {
+    const track = subtitlesToTrack(entries, 'Test');
+
+    expect(track.id).toMatch(/^track-text-/);
+    expect(track.clips).toHaveLength(2);
+    expect(track.clips[0].id).toMatch(/^text-/);
+  });
+
+  it('クリップのプロパティが正しくマッピングされる', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const track = subtitlesToTrack(entries, 'Sub', idGen);
+
+    expect(track.type).toBe('text');
+    expect(track.name).toBe('Sub');
+    expect(track.clips[0].name).toBe('Hello');
+    expect(track.clips[0].startTime).toBe(0);
+    expect(track.clips[0].duration).toBe(2);
+    expect(track.clips[1].name).toBe('World');
+    expect(track.clips[1].startTime).toBe(3);
+    expect(track.clips[1].duration).toBe(2);
+  });
+
+  it('テキストプロパティにentryのtextが設定される', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const track = subtitlesToTrack(entries, 'Sub', idGen);
+
+    expect(track.clips[0].textProperties?.text).toBe('Hello');
+    expect(track.clips[1].textProperties?.text).toBe('World');
+  });
+
+  it('空の配列を渡すとクリップなしのトラックを返す', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const track = subtitlesToTrack([], 'Empty', idGen);
+
+    expect(track.clips).toHaveLength(0);
+    expect(track.type).toBe('text');
+  });
+});
+
+describe('trackToSubtitles', () => {
+  it('クリップからSubtitleEntryに正しく変換する', () => {
+    const idGen = (prefix: string) => `${prefix}-id`;
+    const entries: SubtitleEntry[] = [
+      { startTime: 1, endTime: 3, text: 'Test subtitle' },
+    ];
+    const track = subtitlesToTrack(entries, 'Sub', idGen);
+    const result = trackToSubtitles(track);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].startTime).toBe(1);
+    expect(result[0].endTime).toBe(3);
+    expect(result[0].text).toBe('Test subtitle');
+  });
+});
+
+describe('parseSRT / exportSRT', () => {
+  const srtContent = `1
+00:00:01,000 --> 00:00:03,500
+Hello World
+
+2
+00:00:05,000 --> 00:00:08,000
+Second line
+`;
+
+  it('SRTをパースできる', () => {
+    const entries = parseSRT(srtContent);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].startTime).toBe(1);
+    expect(entries[0].endTime).toBeCloseTo(3.5);
+    expect(entries[0].text).toBe('Hello World');
+    expect(entries[1].startTime).toBe(5);
+    expect(entries[1].endTime).toBe(8);
+  });
+
+  it('SRTにエクスポートできる', () => {
+    const entries: SubtitleEntry[] = [
+      { startTime: 1, endTime: 3.5, text: 'Hello World' },
+    ];
+    const result = exportSRT(entries);
+    expect(result).toContain('00:00:01,000 --> 00:00:03,500');
+    expect(result).toContain('Hello World');
+  });
+});
+
+describe('parseASS / exportASS', () => {
+  const assContent = `[Script Info]
+Title: Test
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.50,Default,,0,0,0,,Hello World
+`;
+
+  it('ASSをパースできる', () => {
+    const entries = parseASS(assContent);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].startTime).toBe(1);
+    expect(entries[0].endTime).toBeCloseTo(3.5);
+    expect(entries[0].text).toBe('Hello World');
+  });
+
+  it('ASSにエクスポートできる', () => {
+    const entries: SubtitleEntry[] = [
+      { startTime: 1, endTime: 3.5, text: 'Hello World' },
+    ];
+    const result = exportASS(entries);
+    expect(result).toContain('[Events]');
+    expect(result).toContain('Hello World');
+  });
+});

--- a/src/utils/subtitles.ts
+++ b/src/utils/subtitles.ts
@@ -150,9 +150,17 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
 // --- Track conversion ---
 
-export function subtitlesToTrack(entries: SubtitleEntry[], trackName = 'Subtitle'): Track {
-  const clips: Clip[] = entries.map((entry, i) => ({
-    id: `text-${Date.now()}-${i}`,
+function defaultIdGenerator(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function subtitlesToTrack(
+  entries: SubtitleEntry[],
+  trackName = 'Subtitle',
+  idGenerator: (prefix: string) => string = defaultIdGenerator,
+): Track {
+  const clips: Clip[] = entries.map((entry) => ({
+    id: idGenerator('text'),
     name: entry.text.substring(0, 20),
     startTime: entry.startTime,
     duration: entry.endTime - entry.startTime,
@@ -168,7 +176,7 @@ export function subtitlesToTrack(entries: SubtitleEntry[], trackName = 'Subtitle
   }));
 
   return {
-    id: `track-text-${Date.now()}`,
+    id: idGenerator('track-text'),
     type: 'text',
     name: trackName,
     clips,


### PR DESCRIPTION
## 概要
`subtitlesToTrack` 関数が内部で `Date.now()` を直接呼び出しており参照透過性が欠けていた問題を修正。

## 変更内容
- `subtitlesToTrack` に `idGenerator` オプション引数を追加（デフォルトは従来の `Date.now()+Math.random()` ベース）
- テスト時は固定IDジェネレータを注入して決定的にテスト可能に
- `subtitles.test.ts` を新規追加（parseSRT/exportSRT/parseASS/exportASS のテストも含む、計10件）

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run test` パス
- [x] `npm run build` パス
- [ ] 字幕ファイル（SRT/ASS）をインポートしてタイムラインにトラックが追加されることを確認