### PR TITLE
プリセットストアの ID 生成を generateId に統一

### DIFF
--- a/src/store/colorPresetStore.ts
+++ b/src/store/colorPresetStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
+import { generateId } from '../utils/idGenerator';
 import type { ColorPreset } from '../data/colorPresets';
 import { BUILT_IN_COLOR_PRESETS } from '../data/colorPresets';
 import type { ColorEffectFields } from '../data/colorPresets';
@@ -47,7 +48,7 @@ export const useColorPresetStore = create<ColorPresetState>((set, get) => ({
   },
 
   addPreset: async (name, effects) => {
-    const id = `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const id = generateId('custom');
     const newPreset: ColorPreset = { id, name, category: 'custom', effects, isBuiltIn: false };
     const updated = [...get().customPresets, newPreset];
     set({ customPresets: updated });

--- a/src/store/effectPresetStore.ts
+++ b/src/store/effectPresetStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
+import { generateId } from '../utils/idGenerator';
 import type { EffectPreset, EffectPresetCategory } from '../data/effectPresets';
 import { BUILT_IN_EFFECT_PRESETS } from '../data/effectPresets';
 import type { ClipEffects } from './timelineStore';
@@ -66,7 +67,7 @@ export const useEffectPresetStore = create<EffectPresetState>((set, get) => ({
   },
 
   addPreset: async (name, effects) => {
-    const id = `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const id = generateId('custom');
     const newPreset: EffectPreset = { id, name, category: 'custom', effects, isBuiltIn: false };
     const updated = [...get().customPresets, newPreset];
     set({ customPresets: updated });

--- a/src/store/transitionPresetStore.ts
+++ b/src/store/transitionPresetStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
+import { generateId } from '../utils/idGenerator';
 import type { TransitionType } from './timelineStore';
 
 export interface TransitionPreset {
@@ -61,7 +62,7 @@ export const useTransitionPresetStore = create<TransitionPresetState>((set, get)
   },
 
   addPreset: async (name, type, duration) => {
-    const id = `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const id = generateId('custom');
     const newPreset: TransitionPreset = { id, name, type, duration, isBuiltIn: false };
     const updated = [...get().customPresets, newPreset];
     set({ customPresets: updated });

--- a/src/test/colorPresetStore.test.ts
+++ b/src/test/colorPresetStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useColorPresetStore } from '../store/colorPresetStore';
 import { BUILT_IN_COLOR_PRESETS } from '../data/colorPresets';
 
@@ -63,5 +63,24 @@ describe('colorPresetStore', () => {
     await useColorPresetStore.getState().removePreset(id);
     const all = useColorPresetStore.getState().getAllPresets();
     expect(all.length).toBe(BUILT_IN_COLOR_PRESETS.length);
+  });
+
+  it('should generate deterministic id when Date.now and Math.random are mocked', async () => {
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValueOnce(3000).mockReturnValueOnce(4000);
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValueOnce(0.3).mockReturnValueOnce(0.7);
+    await useColorPresetStore.getState().addPreset('A', {});
+    await useColorPresetStore.getState().addPreset('B', {});
+    dateSpy.mockRestore();
+    randomSpy.mockRestore();
+    const customs = useColorPresetStore.getState().customPresets;
+    expect(customs[0].id).toBe(`custom-3000-${(0.3).toString(36).slice(2, 8)}`);
+    expect(customs[1].id).toBe(`custom-4000-${(0.7).toString(36).slice(2, 8)}`);
+    expect(customs[0].id).not.toBe(customs[1].id);
+  });
+
+  it('should not throw when removing non-existent id', async () => {
+    await useColorPresetStore.getState().addPreset('Keep', { brightness: 1.0 });
+    await useColorPresetStore.getState().removePreset('non-existent-id');
+    expect(useColorPresetStore.getState().customPresets).toHaveLength(1);
   });
 });

--- a/src/test/transitionPreset.test.ts
+++ b/src/test/transitionPreset.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useTransitionPresetStore, BUILT_IN_PRESETS } from '../store/transitionPresetStore';
 
 describe('transition preset store', () => {
@@ -96,6 +96,25 @@ describe('transition preset store', () => {
       const remaining = useTransitionPresetStore.getState().customPresets;
       expect(remaining).toHaveLength(1);
       expect(remaining[0].name).toBe('Keep');
+    });
+
+    it('should generate deterministic id when Date.now and Math.random are mocked', async () => {
+      const dateSpy = vi.spyOn(Date, 'now').mockReturnValueOnce(5000).mockReturnValueOnce(6000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValueOnce(0.2).mockReturnValueOnce(0.8);
+      await useTransitionPresetStore.getState().addPreset('A', 'crossfade', 1.0);
+      await useTransitionPresetStore.getState().addPreset('B', 'dissolve', 2.0);
+      dateSpy.mockRestore();
+      randomSpy.mockRestore();
+      const customs = useTransitionPresetStore.getState().customPresets;
+      expect(customs[0].id).toBe(`custom-5000-${(0.2).toString(36).slice(2, 8)}`);
+      expect(customs[1].id).toBe(`custom-6000-${(0.8).toString(36).slice(2, 8)}`);
+      expect(customs[0].id).not.toBe(customs[1].id);
+    });
+
+    it('should not throw when removing non-existent id', async () => {
+      await useTransitionPresetStore.getState().addPreset('Keep', 'crossfade', 1.0);
+      await useTransitionPresetStore.getState().removePreset('non-existent-id');
+      expect(useTransitionPresetStore.getState().customPresets).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## 概要
3つのプリセットストアで重複していた `Date.now()` + `Math.random()` による ID 生成を、PR #232 で導入した共通の `generateId` ユーティリティに統一。

## 依存関係
- **PR #232** (`refactor/extract-id-generator`) を先にマージすること

## 変更内容
- `effectPresetStore.ts`, `transitionPresetStore.ts`, `colorPresetStore.ts`: `addPreset` 内の ID 生成を `generateId('custom')` に変更
- `transitionPreset.test.ts`, `colorPresetStore.test.ts`: モック付き決定的IDテスト、存在しないID削除テスト追加

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run test` パス（35件）
- [x] `npm run build` パス
- [ ] エフェクトプリセットを追加して ID が `custom-` で始まることを確認
- [ ] トランジションプリセットを追加して同様に確認
- [ ] カラープリセットを追加して同様に確認