### PR TITLE
addRecentProject と setStatus の Date.now() をオプション引数化

### DIFF
--- a/src/store/exportStore.ts
+++ b/src/store/exportStore.ts
@@ -39,7 +39,7 @@ export interface ExportState {
   formatOptions: FormatOption[];
   customFormatProfiles: Record<string, ExportFormatProfile>;
 
-  setStatus: (status: ExportStatus) => void;
+  setStatus: (status: ExportStatus, timestamp?: number) => void;
   setProgress: (progress: number, currentTime: number) => void;
   setError: (message: string) => void;
   setDialogOpen: (open: boolean) => void;
@@ -71,9 +71,9 @@ export const useExportStore = create<ExportState>((set) => ({
   formatOptions: DEFAULT_FORMAT_OPTIONS,
   customFormatProfiles: {},
 
-  setStatus: (status) => set((state) => ({
+  setStatus: (status, timestamp = Date.now()) => set((state) => ({
     status,
-    exportStartedAt: status === 'exporting' ? (state.exportStartedAt ?? Date.now()) : state.exportStartedAt,
+    exportStartedAt: status === 'exporting' ? (state.exportStartedAt ?? timestamp) : state.exportStartedAt,
   })),
   setProgress: (progress, currentTime) => set({ progress, currentTime }),
   setError: (message) => set({ status: 'error', errorMessage: message }),

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -67,7 +67,7 @@ export interface ProjectState {
 
   // 最近のプロジェクト
   loadRecentProjects: () => Promise<void>;
-  addRecentProject: (name: string, path: string) => Promise<void>;
+  addRecentProject: (name: string, path: string, timestamp?: number) => Promise<void>;
   removeRecentProject: (path: string) => Promise<void>;
   clearRecentProjects: () => Promise<void>;
 }
@@ -488,11 +488,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }
   },
 
-  addRecentProject: async (name: string, path: string) => {
+  addRecentProject: async (name: string, path: string, timestamp: number = Date.now()) => {
     const { recentProjects } = get();
     const filtered = recentProjects.filter((p) => p.path !== path);
     const updated: RecentProject[] = [
-      { name, path, lastOpened: Date.now(), exists: true },
+      { name, path, lastOpened: timestamp, exists: true },
       ...filtered,
     ].slice(0, MAX_RECENT_PROJECTS);
 

--- a/src/test/exportStore.test.ts
+++ b/src/test/exportStore.test.ts
@@ -96,6 +96,29 @@ describe('exportStore', () => {
     expect(result.current.outputPath).toBe('/tmp/output.mp4');
   });
 
+  it('setStatus に固定タイムスタンプを渡すと決定的に exportStartedAt が設定される', () => {
+    const { result } = renderHook(() => useExportStore());
+
+    act(() => {
+      result.current.setStatus('exporting', 1700000000000);
+    });
+
+    expect(result.current.exportStartedAt).toBe(1700000000000);
+  });
+
+  it('setStatus で既に exportStartedAt がある場合は上書きしない', () => {
+    const { result } = renderHook(() => useExportStore());
+
+    act(() => {
+      result.current.setStatus('exporting', 1000);
+    });
+    act(() => {
+      result.current.setStatus('exporting', 2000);
+    });
+
+    expect(result.current.exportStartedAt).toBe(1000);
+  });
+
   it('リセットで初期状態に戻る', () => {
     const { result } = renderHook(() => useExportStore());
 

--- a/src/test/exportStore.test.ts
+++ b/src/test/exportStore.test.ts
@@ -119,6 +119,46 @@ describe('exportStore', () => {
     expect(result.current.exportStartedAt).toBe(1000);
   });
 
+  it('exporting 以外のステータスに変更しても exportStartedAt は保持される', () => {
+    const { result } = renderHook(() => useExportStore());
+
+    act(() => {
+      result.current.setStatus('exporting', 5000);
+    });
+    expect(result.current.exportStartedAt).toBe(5000);
+
+    act(() => {
+      result.current.setStatus('complete');
+    });
+    expect(result.current.status).toBe('complete');
+    expect(result.current.exportStartedAt).toBe(5000);
+  });
+
+  it('idle → exporting → complete → idle のステータス遷移', () => {
+    const { result } = renderHook(() => useExportStore());
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.exportStartedAt).toBeNull();
+
+    act(() => {
+      result.current.setStatus('exporting', 1000);
+    });
+    expect(result.current.status).toBe('exporting');
+    expect(result.current.exportStartedAt).toBe(1000);
+
+    act(() => {
+      result.current.setStatus('complete');
+    });
+    expect(result.current.status).toBe('complete');
+    expect(result.current.exportStartedAt).toBe(1000);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.exportStartedAt).toBeNull();
+  });
+
   it('リセットで初期状態に戻る', () => {
     const { result } = renderHook(() => useExportStore());
 

--- a/src/test/projectStore.test.ts
+++ b/src/test/projectStore.test.ts
@@ -601,6 +601,15 @@ describe('projectStore', () => {
     expect(recentProjects[1].exists).toBe(false);
   });
 
+  it('addRecentProject に固定タイムスタンプを渡すと決定的に lastOpened が設定される', async () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    await useProjectStore.getState().addRecentProject('Test', '/tmp/test.qcut', 1700000000000);
+
+    const { recentProjects } = useProjectStore.getState();
+    expect(recentProjects[0].lastOpened).toBe(1700000000000);
+  });
+
   it('addRecentProject で先頭に追加され最大10件に制限される', async () => {
     const existing = Array.from({ length: 10 }, (_, i) => ({
       name: `Project${i}`,


### PR DESCRIPTION
## 概要
`addRecentProject` と `exportStore.setStatus` が内部で `Date.now()` を直接呼び出しており、テスト時にタイムスタンプを固定できなかった問題を修正。

## 変更内容
- `addRecentProject` に `timestamp` オプション引数を追加（デフォルト: `Date.now()`）
- `exportStore.setStatus` に `timestamp` オプション引数を追加（デフォルト: `Date.now()`）
- `projectStore.test.ts`: 固定タイムスタンプでの `addRecentProject` テスト1件追加
- `exportStore.test.ts`: 固定タイムスタンプでの `setStatus` テスト2件追加（決定的設定、上書き防止）

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run test` パス（53件）
- [x] `npm run build` パス
- [ ] プロジェクト保存後に「最近のプロジェクト」に追加されることを確認
- [ ] エクスポート開始時に経過時間が正常に表示されることを確認