### PR TITLE
clipboardSlice / subtitles のフォールバック ID 生成を generateId に統一

### DIFF
--- a/src/store/timeline/clipboardSlice.ts
+++ b/src/store/timeline/clipboardSlice.ts
@@ -2,6 +2,7 @@ import type { StoreApi } from 'zustand';
 import { logAction } from '../actionLogger';
 import type { TimelineState, Clip, Track } from './types';
 import { withHistory } from './historySlice';
+import { generateId } from '../../utils/idGenerator';
 
 type Set = StoreApi<TimelineState>['setState'];
 
@@ -35,18 +36,14 @@ export function resolveTargetTrackId(
   return resolvedTrackId;
 }
 
-function defaultGenerateId(): string {
-  return `clip-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
 export function buildPastedClip(
   sourceClip: Clip,
   currentTime: number,
-  generateId: () => string = defaultGenerateId,
+  idGenerator: () => string = () => generateId('clip'),
 ): Clip {
   return {
     ...JSON.parse(JSON.stringify(sourceClip)),
-    id: generateId(),
+    id: idGenerator(),
     startTime: currentTime,
   };
 }

--- a/src/utils/subtitles.ts
+++ b/src/utils/subtitles.ts
@@ -1,5 +1,6 @@
 import type { Track, Clip, TextProperties } from '../store/timelineStore';
 import { DEFAULT_TEXT_PROPERTIES } from '../store/timelineStore';
+import { generateId } from './idGenerator';
 
 export interface SubtitleEntry {
   startTime: number;
@@ -150,14 +151,10 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
 // --- Track conversion ---
 
-function defaultIdGenerator(prefix: string): string {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
 export function subtitlesToTrack(
   entries: SubtitleEntry[],
   trackName = 'Subtitle',
-  idGenerator: (prefix: string) => string = defaultIdGenerator,
+  idGenerator: (prefix: string) => string = generateId,
 ): Track {
   const clips: Clip[] = entries.map((entry) => ({
     id: idGenerator('text'),


### PR DESCRIPTION
## 概要
`clipboardSlice` と `subtitles.ts` に残っていた独自フォールバック ID 生成関数を削除し、共通の `generateId` に統一。

## 変更内容
- `clipboardSlice.ts`: `defaultGenerateId` を削除、`generateId('clip')` をデフォルトに
- `subtitles.ts`: `defaultIdGenerator` を削除、`generateId` をデフォルトに

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run test` パス（31件）
- [x] `npm run build` パス
- [ ] クリップのコピー＆ペーストが正常に動作することを確認
- [ ] 字幕ファイルのインポートが正常に動作することを確認