### PR TITLE
App.tsx のテキストトラック ID 生成を generateId に統一

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { ShortcutHelp } from './components/ShortcutHelp/ShortcutHelp';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useTimelineStore } from './store/timelineStore';
 import { DEFAULT_TEXT_PROPERTIES } from './store/timelineStore';
+import { generateId } from './utils/idGenerator';
 import { useVideoPreviewStore } from './store/videoPreviewStore';
 import { useExportStore } from './store/exportStore';
 import { useShortcutStore } from './store/shortcutStore';
@@ -106,10 +107,10 @@ function App() {
 
   const handleAddTextTrack = useCallback(() => {
     const { addTrack, addClip, tracks } = useTimelineStore.getState();
-    const trackId = `track-text-${Date.now()}`;
+    const trackId = generateId('track-text');
     addTrack({ id: trackId, type: 'text', name: `Text ${tracks.filter((t) => t.type === 'text').length + 1}`, clips: [] });
     addClip(trackId, {
-      id: `text-${Date.now()}`,
+      id: generateId('text'),
       name: 'テキスト',
       startTime: useTimelineStore.getState().currentTime,
       duration: 3,

--- a/src/test/addTextTrack.test.ts
+++ b/src/test/addTextTrack.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useTimelineStore } from '../store/timelineStore';
+import { DEFAULT_TEXT_PROPERTIES } from '../store/timelineStore';
+import { generateId } from '../utils/idGenerator';
+
+describe('handleAddTextTrack 相当のフロー', () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [],
+      currentTime: 5,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('テキストトラックとクリップが generateId で追加される', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const { addTrack, addClip, tracks } = useTimelineStore.getState();
+    const trackId = generateId('track-text');
+    addTrack({ id: trackId, type: 'text', name: `Text ${tracks.filter((t) => t.type === 'text').length + 1}`, clips: [] });
+    addClip(trackId, {
+      id: generateId('text'),
+      name: 'テキスト',
+      startTime: useTimelineStore.getState().currentTime,
+      duration: 3,
+      color: '#e6a817',
+      filePath: '',
+      sourceStartTime: 0,
+      sourceEndTime: 0,
+      textProperties: { ...DEFAULT_TEXT_PROPERTIES },
+    });
+
+    const state = useTimelineStore.getState();
+    const textTrack = state.tracks.find(t => t.type === 'text');
+    expect(textTrack).toBeDefined();
+    expect(textTrack!.id).toMatch(/^track-text-/);
+    expect(textTrack!.name).toBe('Text 1');
+    expect(textTrack!.clips).toHaveLength(1);
+
+    const clip = textTrack!.clips[0];
+    expect(clip.id).toMatch(/^text-/);
+    expect(clip.startTime).toBe(5);
+    expect(clip.duration).toBe(3);
+    expect(clip.textProperties).toEqual(DEFAULT_TEXT_PROPERTIES);
+  });
+
+  it('複数回追加するとトラック名が連番になる', () => {
+    const { addTrack, addClip } = useTimelineStore.getState();
+
+    // 1つ目
+    const trackId1 = generateId('track-text');
+    addTrack({ id: trackId1, type: 'text', name: 'Text 1', clips: [] });
+    addClip(trackId1, {
+      id: generateId('text'),
+      name: 'テキスト',
+      startTime: 0,
+      duration: 3,
+      color: '#e6a817',
+      filePath: '',
+      sourceStartTime: 0,
+      sourceEndTime: 0,
+      textProperties: { ...DEFAULT_TEXT_PROPERTIES },
+    });
+
+    // 2つ目
+    const tracks = useTimelineStore.getState().tracks;
+    const trackId2 = generateId('track-text');
+    addTrack({ id: trackId2, type: 'text', name: `Text ${tracks.filter(t => t.type === 'text').length + 1}`, clips: [] });
+
+    const state = useTimelineStore.getState();
+    const textTracks = state.tracks.filter(t => t.type === 'text');
+    expect(textTracks).toHaveLength(2);
+    expect(textTracks[1].name).toBe('Text 2');
+  });
+});


### PR DESCRIPTION
## 概要
`handleAddTextTrack` 内の `Date.now()` による ID 生成を `generateId` に統一。

## 変更内容
- `App.tsx`: トラックID・クリップIDの生成を `generateId('track-text')`, `generateId('text')` に変更

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run build` パス
- [ ] テキストトラック追加ボタンでトラックとクリップが正常に追加されることを確認