### PR TITLE
プラグインシステムの ID 生成を generateId に統一

### DIFF
--- a/src/plugin-system/context.ts
+++ b/src/plugin-system/context.ts
@@ -3,6 +3,7 @@ import type { Clip } from '@/store/timelineStore';
 import { logAction } from '@/store/actionLogger';
 import { usePluginStore } from '@/store/pluginStore';
 import { useExportStore } from '@/store/exportStore';
+import { generateId } from '@/utils/idGenerator';
 import type { PluginManifest, PluginPermission } from './types/manifest';
 import type {
   PluginContext,
@@ -111,7 +112,7 @@ export class PluginContextImpl implements PluginContext {
 
       addClip: (trackId: string, clip: Omit<Clip, 'id'>): string => {
         this.requirePermission('timeline:write');
-        const id = `plugin-clip-${Date.now()}`;
+        const id = generateId('plugin-clip');
         useTimelineStore.getState().addClip(trackId, { ...clip, id });
         return id;
       },
@@ -185,13 +186,13 @@ export class PluginContextImpl implements PluginContext {
 
       showNotification: (message: string, type: 'info' | 'warning' | 'error') => {
         const store = usePluginStore.getState();
-        const id = `notif-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+        const id = generateId('notif');
         store.addNotification({
           id,
           pluginId: this.pluginId,
           message,
           type,
-          timestamp: Date.now(),
+          timestamp: Date.now(),  // UI 表示用タイムスタンプ
         });
         // 5秒後に自動削除。プラグインのライフサイクルに紐づけるため Disposable として登録
         const timeoutId = setTimeout(() => {

--- a/src/plugin-system/manager.ts
+++ b/src/plugin-system/manager.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { usePluginStore } from '@/store/pluginStore';
 import { logAction } from '@/store/actionLogger';
+import { generateId } from '@/utils/idGenerator';
 import { PluginLoader } from './loader';
 import { PluginContextImpl } from './context';
 import type { QcutPlugin } from './types/plugin';
@@ -221,13 +222,13 @@ export class PluginManager {
       store.setPluginState(pluginId, 'error', message);
 
       const displayName = store.plugins[pluginId]?.manifest.name ?? pluginId;
-      const notifId = `plugin-error-${pluginId}-${Date.now()}`;
+      const notifId = generateId(`plugin-error-${pluginId}`);
       store.addNotification({
         id: notifId,
         pluginId,
         message: `プラグイン "${displayName}" でエラーが発生しました: ${message}`,
         type: 'error',
-        timestamp: Date.now(),
+        timestamp: Date.now(),  // UI 表示用タイムスタンプ
       });
       setTimeout(() => {
         usePluginStore.getState().removeNotification(notifId);

--- a/src/test/pluginContext.test.ts
+++ b/src/test/pluginContext.test.ts
@@ -10,12 +10,14 @@ vi.mock('@/store/actionLogger', () => ({
   logAction: vi.fn(),
 }));
 
+const mockTimelineAddClip = vi.fn();
+
 vi.mock('@/store/timelineStore', () => ({
   useTimelineStore: {
     getState: vi.fn(() => ({
       tracks: [],
       currentTime: 0,
-      addClip: vi.fn(),
+      addClip: mockTimelineAddClip,
       updateClip: vi.fn(),
       removeClip: vi.fn(),
     })),
@@ -151,6 +153,68 @@ describe('PluginContextImpl', () => {
       ctx.disposeAll();
 
       expect(mockUnregisterCustomFormat).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('timeline.addClip()', () => {
+    it('generateId で plugin-clip- プレフィックスの ID を生成してクリップを追加する', () => {
+      const manifest = { ...baseManifest, permissions: ['timeline:write'] as PluginManifest['permissions'] };
+      const ctx = new PluginContextImpl('com.test.plugin', manifest);
+
+      const clipData = {
+        name: 'test.mp4',
+        startTime: 0,
+        duration: 5,
+        filePath: '/test.mp4',
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      };
+
+      const id = ctx.timeline.addClip('track-1', clipData);
+
+      expect(id).toMatch(/^plugin-clip-/);
+      expect(mockTimelineAddClip).toHaveBeenCalledWith('track-1', expect.objectContaining({
+        ...clipData,
+        id,
+      }));
+    });
+
+    it('timeline:write 権限なしで呼ぶと PluginPermissionError がスローされる', () => {
+      const manifest = { ...baseManifest, permissions: [] as PluginManifest['permissions'] };
+      const ctx = new PluginContextImpl('com.test.plugin', manifest);
+
+      expect(() => ctx.timeline.addClip('track-1', {
+        name: 'test.mp4', startTime: 0, duration: 5, filePath: '', sourceStartTime: 0, sourceEndTime: 5,
+      })).toThrow(PluginPermissionError);
+    });
+  });
+
+  describe('ui.showNotification()', () => {
+    it('generateId で notif- プレフィックスの ID を生成して通知を追加する', () => {
+      const manifest = { ...baseManifest, permissions: [] as PluginManifest['permissions'] };
+      const ctx = new PluginContextImpl('com.test.plugin', manifest);
+
+      ctx.ui.showNotification('テストメッセージ', 'info');
+
+      expect(mockAddNotification).toHaveBeenCalledWith(expect.objectContaining({
+        id: expect.stringMatching(/^notif-/),
+        pluginId: 'com.test.plugin',
+        message: 'テストメッセージ',
+        type: 'info',
+        timestamp: expect.any(Number),
+      }));
+    });
+
+    it('通知ごとに異なる ID が生成される', () => {
+      const manifest = { ...baseManifest, permissions: [] as PluginManifest['permissions'] };
+      const ctx = new PluginContextImpl('com.test.plugin', manifest);
+
+      ctx.ui.showNotification('msg1', 'info');
+      ctx.ui.showNotification('msg2', 'warning');
+
+      const calls = mockAddNotification.mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[0][0].id).not.toBe(calls[1][0].id);
     });
   });
 });


### PR DESCRIPTION
## 概要
プラグインシステム内の `Date.now()+Math.random()` による ID 生成を `generateId` に統一。

## 変更内容
- `context.ts`: プラグインクリップ ID (`plugin-clip-*`) と通知 ID (`notif-*`) を `generateId` に変更
- `manager.ts`: エラー通知 ID (`plugin-error-*`) を `generateId` に変更
- `timestamp: Date.now()` は UI 表示用タイムスタンプとして変更なし

## 手動テスト手順
- [x] `npm run lint` パス
- [x] `npm run build` パス
- [ ] プラグインからクリップ追加が正常に動作することを確認
- [ ] プラグインの通知表示が正常に動作することを確認