### PR TITLE
refactor: isolate deterministic id formatting

### DIFF
--- a/src/test/idGenerator.test.ts
+++ b/src/test/idGenerator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { generateId } from '../utils/idGenerator';
+import { buildId, generateId } from '../utils/idGenerator';
 
 describe('generateId', () => {
   afterEach(() => {
@@ -7,35 +7,36 @@ describe('generateId', () => {
   });
 
   it('指定したprefixで始まるIDを生成する', () => {
-    const id = generateId('clip');
+    const id = buildId('clip', { timestamp: 123, randomValue: 0.25 });
     expect(id.startsWith('clip-')).toBe(true);
   });
 
-  it('Date.now と Math.random を使って決定的なIDを生成する', () => {
+  it('外部入力を固定すれば決定的なIDを生成する', () => {
+    const id = buildId('test', { timestamp: 1000000, randomValue: 0.123456789 });
+    expect(id).toBe('test-1000000-4fzzzx');
+  });
+
+  it('同じ入力で同じIDを返す（参照透過性）', () => {
+    const entropy = { timestamp: 9999, randomValue: 0.5 };
+    const id1 = buildId('clip', entropy);
+    const id2 = buildId('clip', entropy);
+    expect(id1).toBe(id2);
+  });
+
+  it('異なるprefixで異なるIDを返す', () => {
+    const entropy = { timestamp: 1000, randomValue: 0.1 };
+    const id1 = buildId('clip', entropy);
+    const id2 = buildId('track', entropy);
+    expect(id1).not.toBe(id2);
+    expect(id1.startsWith('clip-')).toBe(true);
+    expect(id2.startsWith('track-')).toBe(true);
+  });
+
+  it('generateId は既定で現在時刻と乱数を使う', () => {
     vi.spyOn(Date, 'now').mockReturnValue(1000000);
     vi.spyOn(Math, 'random').mockReturnValue(0.123456789);
 
     const id = generateId('test');
     expect(id).toBe('test-1000000-4fzzzx');
-  });
-
-  it('同じ入力で同じIDを返す（参照透過性）', () => {
-    vi.spyOn(Date, 'now').mockReturnValue(9999);
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
-
-    const id1 = generateId('clip');
-    const id2 = generateId('clip');
-    expect(id1).toBe(id2);
-  });
-
-  it('異なるprefixで異なるIDを返す', () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1000);
-    vi.spyOn(Math, 'random').mockReturnValue(0.1);
-
-    const id1 = generateId('clip');
-    const id2 = generateId('track');
-    expect(id1).not.toBe(id2);
-    expect(id1.startsWith('clip-')).toBe(true);
-    expect(id2.startsWith('track-')).toBe(true);
   });
 });

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -1,9 +1,25 @@
 /**
- * ユニークID生成ユーティリティ
- *
- * Date.now() と Math.random() を使用してユニークなIDを生成する。
- * テスト時は Date.now / Math.random をモックすることで決定的にテスト可能。
+ * ユニークID生成に必要な外部入力。
+ * 呼び出し元がこの値を固定すれば、ID 生成は参照透過になる。
  */
-export function generateId(prefix: string): string {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+export interface IdEntropy {
+  timestamp: number;
+  randomValue: number;
+}
+
+/**
+ * 純粋な ID フォーマッタ。
+ */
+export function buildId(prefix: string, entropy: IdEntropy): string {
+  return `${prefix}-${entropy.timestamp}-${entropy.randomValue.toString(36).slice(2, 8)}`;
+}
+
+/**
+ * 既定では現在時刻と乱数を使う薄いラッパー。
+ */
+export function generateId(
+  prefix: string,
+  entropy: IdEntropy = { timestamp: Date.now(), randomValue: Math.random() },
+): string {
+  return buildId(prefix, entropy);
 }


### PR DESCRIPTION
## Summary
- extract a pure `buildId` function from `generateId`
- keep the existing runtime API as a thin wrapper over time/random entropy
- update tests to assert referential transparency at the pure-function boundary

## Why
`generateId` mixed deterministic formatting with non-deterministic entropy acquisition. That made the utility harder to reason about from a referential-transparency perspective.

This PR keeps the current call sites intact and only isolates the impure boundary.

## Changes
- add `IdEntropy` and `buildId` in `src/utils/idGenerator.ts`
- keep `generateId` as a small wrapper using `Date.now()` and `Math.random()` by default
- revise `src/test/idGenerator.test.ts` so the referential-transparency assertions target the pure formatter

## Verification
- `npm test -- src/test/idGenerator.test.ts src/test/projectStore.test.ts`
- `npx eslint src/utils/idGenerator.ts src/store/projectStore.ts src/test/idGenerator.test.ts src/test/projectStore.test.ts`

## Risk
Low. The runtime `generateId(prefix)` contract is preserved, and only the deterministic portion is extracted for clearer reasoning and testing.
