### PR TITLE
refactor: avoid mutating project files during path normalization

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -92,19 +92,42 @@ export function buildProjectFile(
   };
 }
 
+function mapProjectClipPaths(
+  projectFile: ProjectFile,
+  mapPath: (filePath: string) => string,
+): ProjectFile {
+  return {
+    ...projectFile,
+    timeline: {
+      ...projectFile.timeline,
+      tracks: projectFile.timeline.tracks.map((track) => ({
+        ...track,
+        clips: track.clips.map((clip) => (
+          clip.filePath
+            ? { ...clip, filePath: mapPath(clip.filePath) }
+            : { ...clip }
+        )),
+      })),
+    },
+  };
+}
+
+export function withRelativeProjectClipPaths(projectFile: ProjectFile, projectDir: string): ProjectFile {
+  return mapProjectClipPaths(projectFile, (filePath) => toRelativePath(filePath, projectDir));
+}
+
+export function withResolvedProjectClipPaths(projectFile: ProjectFile, projectDir: string): ProjectFile {
+  return mapProjectClipPaths(projectFile, (filePath) => resolveRelativePath(filePath, projectDir));
+}
+
 async function writeProjectFile(path: string, projectName: string): Promise<void> {
   const timeline = useTimelineStore.getState();
   const exportSettings = useExportStore.getState().settings;
-  const projectFile = buildProjectFile(projectName, timeline.tracks, exportSettings);
-  // 保存先ディレクトリを基準に素材パスを相対パスに変換
   const projectDir = getDirectoryPath(path);
-  for (const track of projectFile.timeline.tracks) {
-    for (const clip of track.clips) {
-      if (clip.filePath) {
-        clip.filePath = toRelativePath(clip.filePath, projectDir);
-      }
-    }
-  }
+  const projectFile = withRelativeProjectClipPaths(
+    buildProjectFile(projectName, timeline.tracks, exportSettings),
+    projectDir,
+  );
   const content = JSON.stringify(projectFile, null, 2);
   await invoke('save_project', { path, content });
 }
@@ -282,20 +305,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const content = await invoke<string>('read_project', { path });
       const parsed = JSON.parse(content);
       const project = validateProjectFile(parsed);
-
-      // 相対パスを絶対パスに解決（後方互換: 絶対パスはそのまま）
       const projectDir = getDirectoryPath(path);
-      for (const track of project.timeline.tracks) {
-        for (const clip of track.clips) {
-          if (clip.filePath) {
-            clip.filePath = resolveRelativePath(clip.filePath, projectDir);
-          }
-        }
-      }
+      const resolvedProject = withResolvedProjectClipPaths(project, projectDir);
 
-      const missing = await checkMissingFiles(project);
+      const missing = await checkMissingFiles(resolvedProject);
 
-      applyProjectToStores(project);
+      applyProjectToStores(resolvedProject);
 
       const name = path.split('/').pop()?.replace(/\.qcut$/, '')
         ?? path.split('\\').pop()?.replace(/\.qcut$/, '')
@@ -411,7 +426,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
             // loadStatus を 'loading' にして subscriber が autosave をスケジュールしないようにする
             set({ loadStatus: 'loading' });
 
-            applyProjectToStores(project);
+            const projectDir = originalPath ? getDirectoryPath(originalPath) : '';
+            applyProjectToStores(withResolvedProjectClipPaths(project, projectDir));
 
             const name = originalPath
               ? (originalPath.split('/').pop()?.replace(/\.qcut$/, '')

--- a/src/test/projectStore.test.ts
+++ b/src/test/projectStore.test.ts
@@ -14,7 +14,13 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
 
 import { invoke } from '@tauri-apps/api/core';
 import { save, open, ask } from '@tauri-apps/plugin-dialog';
-import { useProjectStore, _resetAutosaveState, buildProjectFile } from '../store/projectStore';
+import {
+  useProjectStore,
+  _resetAutosaveState,
+  buildProjectFile,
+  withRelativeProjectClipPaths,
+  withResolvedProjectClipPaths,
+} from '../store/projectStore';
 import { useTimelineStore } from '../store/timelineStore';
 import { useExportStore } from '../store/exportStore';
 import { useVideoPreviewStore } from '../store/videoPreviewStore';
@@ -91,6 +97,79 @@ describe('projectStore', () => {
     expect(parsed.metadata.name).toBe('無題のプロジェクト');
     expect(parsed.timeline).toBeDefined();
     expect(parsed.exportSettings).toBeDefined();
+  });
+
+  it('withRelativeProjectClipPaths は入力を破壊せずに相対パス化する', () => {
+    const projectFile = buildProjectFile(
+      'test',
+      [
+        {
+          id: 'video-1',
+          type: 'video',
+          name: 'Video 1',
+          volume: 1,
+          mute: false,
+          solo: false,
+          clips: [
+            {
+              id: 'clip-1',
+              name: 'sample.mp4',
+              startTime: 0,
+              duration: 10,
+              filePath: '/tmp/assets/sample.mp4',
+              sourceStartTime: 0,
+              sourceEndTime: 10,
+            },
+          ],
+        },
+      ],
+      useExportStore.getState().settings,
+      '2026-03-08T12:00:00.000Z',
+    );
+
+    const converted = withRelativeProjectClipPaths(projectFile, '/tmp/project');
+
+    expect(projectFile.timeline.tracks[0].clips[0].filePath).toBe('/tmp/assets/sample.mp4');
+    expect(converted.timeline.tracks[0].clips[0].filePath).toBe('../assets/sample.mp4');
+  });
+
+  it('withResolvedProjectClipPaths は入力を破壊せずに絶対パス化する', () => {
+    const projectFile: ProjectFile = {
+      schemaVersion: 2,
+      appVersion: '0.1.0',
+      createdAt: '2026-03-08T12:00:00.000Z',
+      updatedAt: '2026-03-08T12:00:00.000Z',
+      metadata: { name: 'test' },
+      timeline: {
+        tracks: [
+          {
+            id: 'video-1',
+            type: 'video',
+            name: 'Video 1',
+            volume: 1,
+            mute: false,
+            solo: false,
+            clips: [
+              {
+                id: 'clip-1',
+                name: 'sample.mp4',
+                startTime: 0,
+                duration: 10,
+                filePath: '../assets/sample.mp4',
+                sourceStartTime: 0,
+                sourceEndTime: 10,
+              },
+            ],
+          },
+        ],
+      },
+      exportSettings: useExportStore.getState().settings,
+    };
+
+    const converted = withResolvedProjectClipPaths(projectFile, '/tmp/project');
+
+    expect(projectFile.timeline.tracks[0].clips[0].filePath).toBe('../assets/sample.mp4');
+    expect(converted.timeline.tracks[0].clips[0].filePath).toBe('/tmp/assets/sample.mp4');
   });
 
   it('saveProject がタイムラインのトラックデータを含む', async () => {


### PR DESCRIPTION
## Summary
- replace in-place clip path normalization with pure project-file transformations
- use the non-mutating helpers in both save/load flows
- add tests that lock the non-destructive behavior in place

## Why
`projectStore` normalized clip file paths by mutating the validated project object in place. That works operationally, but it weakens referential transparency and makes the transformation boundary harder to reason about.

This PR moves that logic into explicit pure helpers while preserving the current runtime behavior.

## Changes
- add a shared project-file path mapping helper in `src/store/projectStore.ts`
- introduce `withRelativeProjectClipPaths` for save-time normalization
- introduce `withResolvedProjectClipPaths` for load/recovery-time normalization
- update the save, load, and autosave recovery flows to use the pure transformations
- add tests in `src/test/projectStore.test.ts` to verify the original project object is not mutated

## Verification
- `npm test -- src/test/idGenerator.test.ts src/test/projectStore.test.ts`
- `npx eslint src/utils/idGenerator.ts src/store/projectStore.ts src/test/idGenerator.test.ts src/test/projectStore.test.ts`

## Risk
Low. The path normalization semantics are unchanged; the difference is that the conversion now returns new objects instead of mutating existing ones.
