### PR TITLE
refactor: move timeline action logging outside updaters

### DIFF
--- a/src/store/timeline/clipSlice.ts
+++ b/src/store/timeline/clipSlice.ts
@@ -4,51 +4,58 @@ import type { TimelineState, Clip, ClipTransition, ClipEffects, Keyframe, Easing
 import { withHistory } from './historySlice';
 
 type Set = StoreApi<TimelineState>['setState'];
+type Get = StoreApi<TimelineState>['getState'];
 
-export const createClipSlice = (set: Set) => ({
-  addClip: (trackId: string, clip: Clip) => set((state) => {
+export const createClipSlice = (set: Set, get: Get) => ({
+  addClip: (trackId: string, clip: Clip) => {
     logAction('addClip', `track=${trackId} clip=${clip.name}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? { ...track, clips: [...track.clips, clip] }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  removeClip: (trackId: string, clipId: string) => set((state) => {
-    logAction('removeClip', `track=${trackId} clip=${clipId}`);
-    const newTracks = state.tracks
-      .map((track) =>
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
         track.id === trackId
-          ? { ...track, clips: track.clips.filter((clip) => clip.id !== clipId) }
+          ? { ...track, clips: [...track.clips, clip] }
           : track
-      )
-      .filter((track) => track.clips.length > 0);
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-    const isSelectedClipRemoved = state.selectedTrackId === trackId && state.selectedClipId === clipId;
+  removeClip: (trackId: string, clipId: string) => {
+    logAction('removeClip', `track=${trackId} clip=${clipId}`);
+    set((state) => {
+      const newTracks = state.tracks
+        .map((track) =>
+          track.id === trackId
+            ? { ...track, clips: track.clips.filter((clip) => clip.id !== clipId) }
+            : track
+        )
+        .filter((track) => track.clips.length > 0);
 
-    return {
-      ...withHistory(state, newTracks),
-      selectedTrackId: isSelectedClipRemoved ? null : state.selectedTrackId,
-      selectedClipId: isSelectedClipRemoved ? null : state.selectedClipId,
-    };
-  }),
+      const isSelectedClipRemoved = state.selectedTrackId === trackId && state.selectedClipId === clipId;
 
-  updateClip: (trackId: string, clipId: string, updates: Partial<Clip>) => set((state) => {
+      return {
+        ...withHistory(state, newTracks),
+        selectedTrackId: isSelectedClipRemoved ? null : state.selectedTrackId,
+        selectedClipId: isSelectedClipRemoved ? null : state.selectedClipId,
+      };
+    });
+  },
+
+  updateClip: (trackId: string, clipId: string, updates: Partial<Clip>) => {
     logAction('updateClip', `track=${trackId} clip=${clipId} keys=${Object.keys(updates).join(',')}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip =>
-              clip.id === clipId ? { ...clip, ...updates } : clip
-            ),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip =>
+                clip.id === clipId ? { ...clip, ...updates } : clip
+              ),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
   updateClipSilent: (trackId: string, clipId: string, updates: Partial<Clip>) => set((state) => {
     const newTracks = state.tracks.map(track =>
@@ -64,19 +71,16 @@ export const createClipSlice = (set: Set) => ({
     return { tracks: newTracks };
   }),
 
-  splitClipAtTime: (trackId: string, clipId: string, splitTime: number) => set((state) => {
-    logAction('splitClipAtTime', `track=${trackId} clip=${clipId} time=${splitTime.toFixed(2)}`);
-    const track = state.tracks.find(t => t.id === trackId);
-    if (!track) return state;
+  splitClipAtTime: (trackId: string, clipId: string, splitTime: number) => {
+    const track = get().tracks.find(t => t.id === trackId);
+    if (!track) return;
 
     const clip = track.clips.find(c => c.id === clipId);
-    if (!clip) return state;
+    if (!clip) return;
 
     const relativeTime = splitTime - clip.startTime;
-
-    if (relativeTime <= 0 || relativeTime >= clip.duration) {
-      return state;
-    }
+    if (relativeTime <= 0 || relativeTime >= clip.duration) return;
+    logAction('splitClipAtTime', `track=${trackId} clip=${clipId} time=${splitTime.toFixed(2)}`);
 
     const firstClip: Clip = {
       ...clip,
@@ -93,275 +97,299 @@ export const createClipSlice = (set: Set) => ({
       sourceStartTime: clip.sourceStartTime + relativeTime,
     };
 
-    const newTracks = state.tracks.map(t =>
-      t.id === trackId
-        ? {
-            ...t,
-            clips: t.clips.flatMap(c =>
-              c.id === clipId ? [firstClip, secondClip] : [c]
-            ),
-          }
-        : t
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(t =>
+        t.id === trackId
+          ? {
+              ...t,
+              clips: t.clips.flatMap(c =>
+                c.id === clipId ? [firstClip, secondClip] : [c]
+              ),
+            }
+          : t
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-  deleteSelectedClip: () => set((state) => {
-    if (!state.selectedClipId || !state.selectedTrackId) return state;
-    logAction('deleteSelectedClip', `track=${state.selectedTrackId} clip=${state.selectedClipId}`);
+  deleteSelectedClip: () => {
+    const { selectedClipId, selectedTrackId } = get();
+    if (!selectedClipId || !selectedTrackId) return;
+    logAction('deleteSelectedClip', `track=${selectedTrackId} clip=${selectedClipId}`);
+    set((state) => {
+      const newTracks = state.tracks
+        .map((track) =>
+          track.id === selectedTrackId
+            ? {
+                ...track,
+                clips: track.clips.filter((clip) => clip.id !== selectedClipId),
+              }
+            : track
+        )
+        .filter((track) => track.clips.length > 0);
 
-    const newTracks = state.tracks
-      .map((track) =>
-        track.id === state.selectedTrackId
+      return {
+        ...withHistory(state, newTracks),
+        selectedClipId: null,
+        selectedTrackId: null,
+      };
+    });
+  },
+
+  setTransition: (trackId: string, clipId: string, transition: ClipTransition) => {
+    logAction('setTransition', `track=${trackId} clip=${clipId} type=${transition.type}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
           ? {
               ...track,
-              clips: track.clips.filter((clip) => clip.id !== state.selectedClipId),
+              clips: track.clips.map(clip =>
+                clip.id === clipId ? { ...clip, transition } : clip
+              ),
             }
           : track
-      )
-      .filter((track) => track.clips.length > 0);
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-    return {
-      ...withHistory(state, newTracks),
-      selectedClipId: null,
-      selectedTrackId: null,
-    };
-  }),
-
-  setTransition: (trackId: string, clipId: string, transition: ClipTransition) => set((state) => {
-    logAction('setTransition', `track=${trackId} clip=${clipId} type=${transition.type}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip =>
-              clip.id === clipId ? { ...clip, transition } : clip
-            ),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  removeTransition: (trackId: string, clipId: string) => set((state) => {
+  removeTransition: (trackId: string, clipId: string) => {
     logAction('removeTransition', `track=${trackId} clip=${clipId}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip =>
-              clip.id === clipId ? { ...clip, transition: undefined } : clip
-            ),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip =>
+                clip.id === clipId ? { ...clip, transition: undefined } : clip
+              ),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-  addKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, keyframe: Keyframe) => set((state) => {
+  addKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, keyframe: Keyframe) => {
     logAction('addKeyframe', `track=${trackId} clip=${clipId} key=${effectKey} time=${keyframe.time.toFixed(2)}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId) return clip;
-              const existing = clip.keyframes?.[effectKey] ?? [];
-              // 同じ time のキーフレームは上書き
-              const filtered = existing.filter(kf => Math.abs(kf.time - keyframe.time) > 0.001);
-              const updated = [...filtered, keyframe].sort((a, b) => a.time - b.time);
-              return {
-                ...clip,
-                keyframes: { ...clip.keyframes, [effectKey]: updated },
-              };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId) return clip;
+                const existing = clip.keyframes?.[effectKey] ?? [];
+                const filtered = existing.filter(kf => Math.abs(kf.time - keyframe.time) > 0.001);
+                const updated = [...filtered, keyframe].sort((a, b) => a.time - b.time);
+                return {
+                  ...clip,
+                  keyframes: { ...clip.keyframes, [effectKey]: updated },
+                };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-  removeKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number) => set((state) => {
+  removeKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number) => {
     logAction('removeKeyframe', `track=${trackId} clip=${clipId} key=${effectKey} time=${time.toFixed(2)}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId) return clip;
-              const existing = clip.keyframes?.[effectKey] ?? [];
-              const updated = existing.filter(kf => Math.abs(kf.time - time) > 0.001);
-              const newKeyframes = { ...clip.keyframes, [effectKey]: updated };
-              if (updated.length === 0) delete newKeyframes[effectKey];
-              const hasKeys = Object.keys(newKeyframes).length > 0;
-              return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId) return clip;
+                const existing = clip.keyframes?.[effectKey] ?? [];
+                const updated = existing.filter(kf => Math.abs(kf.time - time) > 0.001);
+                const newKeyframes = { ...clip.keyframes, [effectKey]: updated };
+                if (updated.length === 0) delete newKeyframes[effectKey];
+                const hasKeys = Object.keys(newKeyframes).length > 0;
+                return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-  updateKeyframeEasing: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number, easing: EasingType) => set((state) => {
+  updateKeyframeEasing: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number, easing: EasingType) => {
     logAction('updateKeyframeEasing', `track=${trackId} clip=${clipId} key=${effectKey} time=${time.toFixed(2)} easing=${easing}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId) return clip;
-              const existing = clip.keyframes?.[effectKey] ?? [];
-              const updated = existing.map(kf =>
-                Math.abs(kf.time - time) <= 0.001 ? { ...kf, easing } : kf
-              );
-              return { ...clip, keyframes: { ...clip.keyframes, [effectKey]: updated } };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  moveKeyframes: (trackId: string, clipId: string, fromTime: number, toTime: number) => set((state) => {
-    logAction('moveKeyframes', `track=${trackId} clip=${clipId} from=${fromTime.toFixed(2)} to=${toTime.toFixed(2)}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId || !clip.keyframes) return clip;
-              const newKeyframes = { ...clip.keyframes } as typeof clip.keyframes;
-              for (const key of Object.keys(newKeyframes) as Array<keyof ClipEffects>) {
-                const kfs = newKeyframes[key];
-                if (!kfs) continue;
-                const moved = kfs.map(kf =>
-                  Math.abs(kf.time - fromTime) <= 0.001 ? { ...kf, time: toTime } : kf
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId) return clip;
+                const existing = clip.keyframes?.[effectKey] ?? [];
+                const updated = existing.map(kf =>
+                  Math.abs(kf.time - time) <= 0.001 ? { ...kf, easing } : kf
                 );
-                const sorted = moved.sort((a, b) => a.time - b.time);
-                // 同時刻のキーフレームを重複排除（後者を優先、addKeyframe の上書きと同じ挙動）
-                const deduped: typeof sorted = [];
-                for (const kf of sorted) {
-                  const last = deduped[deduped.length - 1];
-                  if (last && Math.abs(last.time - kf.time) <= 0.001) {
-                    deduped[deduped.length - 1] = kf;
+                return { ...clip, keyframes: { ...clip.keyframes, [effectKey]: updated } };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
+
+  moveKeyframes: (trackId: string, clipId: string, fromTime: number, toTime: number) => {
+    logAction('moveKeyframes', `track=${trackId} clip=${clipId} from=${fromTime.toFixed(2)} to=${toTime.toFixed(2)}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId || !clip.keyframes) return clip;
+                const newKeyframes = { ...clip.keyframes } as typeof clip.keyframes;
+                for (const key of Object.keys(newKeyframes) as Array<keyof ClipEffects>) {
+                  const kfs = newKeyframes[key];
+                  if (!kfs) continue;
+                  const moved = kfs.map(kf =>
+                    Math.abs(kf.time - fromTime) <= 0.001 ? { ...kf, time: toTime } : kf
+                  );
+                  const sorted = moved.sort((a, b) => a.time - b.time);
+                  const deduped: typeof sorted = [];
+                  for (const kf of sorted) {
+                    const last = deduped[deduped.length - 1];
+                    if (last && Math.abs(last.time - kf.time) <= 0.001) {
+                      deduped[deduped.length - 1] = kf;
+                    } else {
+                      deduped.push(kf);
+                    }
+                  }
+                  newKeyframes[key] = deduped;
+                }
+                return { ...clip, keyframes: newKeyframes };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
+
+  deleteKeyframesAtTime: (trackId: string, clipId: string, time: number) => {
+    logAction('deleteKeyframesAtTime', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId || !clip.keyframes) return clip;
+                const newKeyframes = { ...clip.keyframes } as typeof clip.keyframes;
+                for (const key of Object.keys(newKeyframes) as Array<keyof ClipEffects>) {
+                  const kfs = newKeyframes[key];
+                  if (!kfs) continue;
+                  const updated = kfs.filter(kf => Math.abs(kf.time - time) > 0.001);
+                  if (updated.length === 0) {
+                    delete newKeyframes[key];
                   } else {
-                    deduped.push(kf);
+                    newKeyframes[key] = updated;
                   }
                 }
-                newKeyframes[key] = deduped;
-              }
-              return { ...clip, keyframes: newKeyframes };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  deleteKeyframesAtTime: (trackId: string, clipId: string, time: number) => set((state) => {
-    logAction('deleteKeyframesAtTime', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId || !clip.keyframes) return clip;
-              const newKeyframes = { ...clip.keyframes } as typeof clip.keyframes;
-              for (const key of Object.keys(newKeyframes) as Array<keyof ClipEffects>) {
-                const kfs = newKeyframes[key];
-                if (!kfs) continue;
-                const updated = kfs.filter(kf => Math.abs(kf.time - time) > 0.001);
-                if (updated.length === 0) {
-                  delete newKeyframes[key];
-                } else {
-                  newKeyframes[key] = updated;
-                }
-              }
-              const hasKeys = Object.keys(newKeyframes).length > 0;
-              return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  addToneCurveKeyframe: (trackId: string, clipId: string, keyframe: ToneCurveKeyframe) => set((state) => {
-    logAction('addToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${keyframe.time.toFixed(2)}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId) return clip;
-              const existing = clip.toneCurveKeyframes ?? [];
-              const filtered = existing.filter(kf => Math.abs(kf.time - keyframe.time) > 0.001);
-              const updated = [...filtered, keyframe].sort((a, b) => a.time - b.time);
-              return { ...clip, toneCurveKeyframes: updated };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  removeToneCurveKeyframe: (trackId: string, clipId: string, time: number) => set((state) => {
-    logAction('removeToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId) return clip;
-              const existing = clip.toneCurveKeyframes ?? [];
-              const updated = existing.filter(kf => Math.abs(kf.time - time) > 0.001);
-              return { ...clip, toneCurveKeyframes: updated.length > 0 ? updated : undefined };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  updateToneCurveKeyframeEasing: (trackId: string, clipId: string, time: number, easing: EasingType) => set((state) => {
-    logAction('updateToneCurveKeyframeEasing', `track=${trackId} clip=${clipId} time=${time.toFixed(2)} easing=${easing}`);
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip => {
-              if (clip.id !== clipId) return clip;
-              const existing = clip.toneCurveKeyframes ?? [];
-              const updated = existing.map(kf =>
-                Math.abs(kf.time - time) <= 0.001 ? { ...kf, easing } : kf
-              );
-              return { ...clip, toneCurveKeyframes: updated };
-            }),
-          }
-        : track
-    );
-    return withHistory(state, newTracks);
-  }),
-
-  moveClipToTrack: (fromTrackId: string, clipId: string, toTrackId: string) => set((state) => {
-    if (fromTrackId === toTrackId) return state;
-    logAction('moveClipToTrack', `clip=${clipId} from=${fromTrackId} to=${toTrackId}`);
-    const fromTrack = state.tracks.find(t => t.id === fromTrackId);
-    if (!fromTrack) return state;
-    const clip = fromTrack.clips.find(c => c.id === clipId);
-    if (!clip) return state;
-    const newTracks = state.tracks.map(track => {
-      if (track.id === fromTrackId) {
-        return { ...track, clips: track.clips.filter(c => c.id !== clipId) };
-      }
-      if (track.id === toTrackId) {
-        return { ...track, clips: [...track.clips, clip] };
-      }
-      return track;
+                const hasKeys = Object.keys(newKeyframes).length > 0;
+                return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
     });
-    return {
-      ...withHistory(state, newTracks),
-      selectedTrackId: toTrackId,
-    };
-  }),
+  },
+
+  addToneCurveKeyframe: (trackId: string, clipId: string, keyframe: ToneCurveKeyframe) => {
+    logAction('addToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${keyframe.time.toFixed(2)}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId) return clip;
+                const existing = clip.toneCurveKeyframes ?? [];
+                const filtered = existing.filter(kf => Math.abs(kf.time - keyframe.time) > 0.001);
+                const updated = [...filtered, keyframe].sort((a, b) => a.time - b.time);
+                return { ...clip, toneCurveKeyframes: updated };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
+
+  removeToneCurveKeyframe: (trackId: string, clipId: string, time: number) => {
+    logAction('removeToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId) return clip;
+                const existing = clip.toneCurveKeyframes ?? [];
+                const updated = existing.filter(kf => Math.abs(kf.time - time) > 0.001);
+                return { ...clip, toneCurveKeyframes: updated.length > 0 ? updated : undefined };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
+
+  updateToneCurveKeyframeEasing: (trackId: string, clipId: string, time: number, easing: EasingType) => {
+    logAction('updateToneCurveKeyframeEasing', `track=${trackId} clip=${clipId} time=${time.toFixed(2)} easing=${easing}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track =>
+        track.id === trackId
+          ? {
+              ...track,
+              clips: track.clips.map(clip => {
+                if (clip.id !== clipId) return clip;
+                const existing = clip.toneCurveKeyframes ?? [];
+                const updated = existing.map(kf =>
+                  Math.abs(kf.time - time) <= 0.001 ? { ...kf, easing } : kf
+                );
+                return { ...clip, toneCurveKeyframes: updated };
+              }),
+            }
+          : track
+      );
+      return withHistory(state, newTracks);
+    });
+  },
+
+  moveClipToTrack: (fromTrackId: string, clipId: string, toTrackId: string) => {
+    if (fromTrackId === toTrackId) return;
+    const fromTrack = get().tracks.find(t => t.id === fromTrackId);
+    if (!fromTrack) return;
+    const clip = fromTrack.clips.find(c => c.id === clipId);
+    if (!clip) return;
+    logAction('moveClipToTrack', `clip=${clipId} from=${fromTrackId} to=${toTrackId}`);
+    set((state) => {
+      const newTracks = state.tracks.map(track => {
+        if (track.id === fromTrackId) {
+          return { ...track, clips: track.clips.filter(c => c.id !== clipId) };
+        }
+        if (track.id === toTrackId) {
+          return { ...track, clips: [...track.clips, clip] };
+        }
+        return track;
+      });
+      return {
+        ...withHistory(state, newTracks),
+        selectedTrackId: toTrackId,
+      };
+    });
+  },
 });

--- a/src/store/timeline/clipboardSlice.ts
+++ b/src/store/timeline/clipboardSlice.ts
@@ -5,6 +5,7 @@ import { withHistory } from './historySlice';
 import { generateId } from '../../utils/idGenerator';
 
 type Set = StoreApi<TimelineState>['setState'];
+type Get = StoreApi<TimelineState>['getState'];
 
 export function resolveTargetTrackId(
   tracks: Track[],
@@ -48,35 +49,42 @@ export function buildPastedClip(
   };
 }
 
-export const createClipboardSlice = (set: Set) => ({
+export const createClipboardSlice = (set: Set, get: Get) => ({
   _clipboard: null as { trackId: string; trackType: Track['type']; clip: Clip } | null,
 
-  copySelectedClip: () => set((state) => {
-    if (!state.selectedClipId || !state.selectedTrackId) return state;
-    logAction('copySelectedClip', `track=${state.selectedTrackId} clip=${state.selectedClipId}`);
+  copySelectedClip: () => {
+    const state = get();
+    if (!state.selectedClipId || !state.selectedTrackId) return;
     const track = state.tracks.find(t => t.id === state.selectedTrackId);
     const clip = track?.clips.find(c => c.id === state.selectedClipId);
-    if (!track || !clip) return state;
-    return { _clipboard: { trackId: state.selectedTrackId, trackType: track.type, clip: JSON.parse(JSON.stringify(clip)) } };
-  }),
+    if (!track || !clip) return;
+    logAction('copySelectedClip', `track=${state.selectedTrackId} clip=${state.selectedClipId}`);
+    set({
+      _clipboard: {
+        trackId: state.selectedTrackId,
+        trackType: track.type,
+        clip: JSON.parse(JSON.stringify(clip)),
+      },
+    });
+  },
 
-  pasteClip: () => set((state) => {
-    if (!state._clipboard) return state;
-    logAction('pasteClip', `clip=${state._clipboard.clip.name}`);
+  pasteClip: () => {
+    const state = get();
+    if (!state._clipboard) return;
     const { clip, trackId: sourceTrackId, trackType: sourceType } = state._clipboard;
-
     const resolvedTrackId = resolveTargetTrackId(
       state.tracks, state.selectedTrackId, sourceTrackId, sourceType,
     );
-    if (!resolvedTrackId) return state;
-
+    if (!resolvedTrackId) return;
+    logAction('pasteClip', `clip=${state._clipboard.clip.name}`);
     const newClip = buildPastedClip(clip, state.currentTime);
-
-    const newTracks = state.tracks.map(t =>
-      t.id === resolvedTrackId
-        ? { ...t, clips: [...t.clips, newClip] }
-        : t
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((currentState) => {
+      const newTracks = currentState.tracks.map(t =>
+        t.id === resolvedTrackId
+          ? { ...t, clips: [...t.clips, newClip] }
+          : t
+      );
+      return withHistory(currentState, newTracks);
+    });
+  },
 });

--- a/src/store/timeline/historySlice.ts
+++ b/src/store/timeline/historySlice.ts
@@ -22,29 +22,35 @@ export const createHistorySlice = (set: Set, get: Get) => ({
   _history: [[]] as Track[][],
   _historyIndex: 0,
 
-  undo: () => set((state) => {
-    if (state._historyIndex <= 0) return state;
+  undo: () => {
+    const state = get();
+    if (state._historyIndex <= 0) return;
     logAction('undo', `index=${state._historyIndex - 1}`);
-    const newIndex = state._historyIndex - 1;
-    return {
-      tracks: JSON.parse(JSON.stringify(state._history[newIndex])),
-      _historyIndex: newIndex,
-      selectedClipId: null,
-      selectedTrackId: null,
-    };
-  }),
+    set((currentState) => {
+      const newIndex = currentState._historyIndex - 1;
+      return {
+        tracks: JSON.parse(JSON.stringify(currentState._history[newIndex])),
+        _historyIndex: newIndex,
+        selectedClipId: null,
+        selectedTrackId: null,
+      };
+    });
+  },
 
-  redo: () => set((state) => {
-    if (state._historyIndex >= state._history.length - 1) return state;
+  redo: () => {
+    const state = get();
+    if (state._historyIndex >= state._history.length - 1) return;
     logAction('redo', `index=${state._historyIndex + 1}`);
-    const newIndex = state._historyIndex + 1;
-    return {
-      tracks: JSON.parse(JSON.stringify(state._history[newIndex])),
-      _historyIndex: newIndex,
-      selectedClipId: null,
-      selectedTrackId: null,
-    };
-  }),
+    set((currentState) => {
+      const newIndex = currentState._historyIndex + 1;
+      return {
+        tracks: JSON.parse(JSON.stringify(currentState._history[newIndex])),
+        _historyIndex: newIndex,
+        selectedClipId: null,
+        selectedTrackId: null,
+      };
+    });
+  },
 
   canUndo: () => get()._historyIndex > 0,
   canRedo: () => {

--- a/src/store/timeline/index.ts
+++ b/src/store/timeline/index.ts
@@ -8,10 +8,10 @@ import { createClipboardSlice } from './clipboardSlice';
 
 export const useTimelineStore = create<TimelineState>((set, get) => ({
   ...createPlaybackSlice(set),
-  ...createTrackSlice(set),
-  ...createClipSlice(set),
+  ...createTrackSlice(set, get),
+  ...createClipSlice(set, get),
   ...createHistorySlice(set, get),
-  ...createClipboardSlice(set),
+  ...createClipboardSlice(set, get),
 }));
 
 // Re-export all types and constants

--- a/src/store/timeline/trackSlice.ts
+++ b/src/store/timeline/trackSlice.ts
@@ -4,46 +4,55 @@ import type { TimelineState, Track } from './types';
 import { withHistory } from './historySlice';
 
 type Set = StoreApi<TimelineState>['setState'];
+type Get = StoreApi<TimelineState>['getState'];
 
-export const createTrackSlice = (set: Set) => ({
+export const createTrackSlice = (set: Set, get: Get) => ({
   tracks: [] as Track[],
 
-  addTrack: (track: Omit<Track, 'volume' | 'mute' | 'solo'> & Partial<Pick<Track, 'volume' | 'mute' | 'solo'>>) => set((state) => {
+  addTrack: (track: Omit<Track, 'volume' | 'mute' | 'solo'> & Partial<Pick<Track, 'volume' | 'mute' | 'solo'>>) => {
     logAction('addTrack', `id=${track.id} type=${track.type}`);
-    const withDefaults: Track = { ...track, volume: track.volume ?? 1.0, mute: track.mute ?? false, solo: track.solo ?? false };
-    return withHistory(state, [...state.tracks, withDefaults]);
-  }),
+    set((state) => {
+      const withDefaults: Track = { ...track, volume: track.volume ?? 1.0, mute: track.mute ?? false, solo: track.solo ?? false };
+      return withHistory(state, [...state.tracks, withDefaults]);
+    });
+  },
 
-  removeTrack: (trackId: string) => set((state) => {
+  removeTrack: (trackId: string) => {
     logAction('removeTrack', `id=${trackId}`);
-    return withHistory(state, state.tracks.filter(t => t.id !== trackId));
-  }),
+    set((state) => withHistory(state, state.tracks.filter(t => t.id !== trackId)));
+  },
 
-  updateTrackVolume: (trackId: string, volume: number) => set((state) => {
+  updateTrackVolume: (trackId: string, volume: number) => {
     logAction('updateTrackVolume', `track=${trackId} volume=${volume.toFixed(2)}`);
-    const newTracks = state.tracks.map(t =>
-      t.id === trackId ? { ...t, volume } : t
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(t =>
+        t.id === trackId ? { ...t, volume } : t
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-  toggleMute: (trackId: string) => set((state) => {
-    const track = state.tracks.find(t => t.id === trackId);
-    if (!track) return state;
+  toggleMute: (trackId: string) => {
+    const track = get().tracks.find(t => t.id === trackId);
+    if (!track) return;
     logAction('toggleMute', `track=${trackId} mute=${!track.mute}`);
-    const newTracks = state.tracks.map(t =>
-      t.id === trackId ? { ...t, mute: !t.mute } : t
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(t =>
+        t.id === trackId ? { ...t, mute: !t.mute } : t
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 
-  toggleSolo: (trackId: string) => set((state) => {
-    const track = state.tracks.find(t => t.id === trackId);
-    if (!track) return state;
+  toggleSolo: (trackId: string) => {
+    const track = get().tracks.find(t => t.id === trackId);
+    if (!track) return;
     logAction('toggleSolo', `track=${trackId} solo=${!track.solo}`);
-    const newTracks = state.tracks.map(t =>
-      t.id === trackId ? { ...t, solo: !t.solo } : t
-    );
-    return withHistory(state, newTracks);
-  }),
+    set((state) => {
+      const newTracks = state.tracks.map(t =>
+        t.id === trackId ? { ...t, solo: !t.solo } : t
+      );
+      return withHistory(state, newTracks);
+    });
+  },
 });

--- a/src/test/timelineActionLogger.test.ts
+++ b/src/test/timelineActionLogger.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../store/actionLogger', () => ({
+  logAction: vi.fn(),
+}));
+
+import { logAction } from '../store/actionLogger';
+import { useTimelineStore } from '../store/timelineStore';
+
+function resetStore() {
+  useTimelineStore.setState({
+    tracks: [],
+    selectedClipId: null,
+    selectedTrackId: null,
+    currentTime: 0,
+    isPlaying: false,
+    pixelsPerSecond: 50,
+    _history: [[]],
+    _historyIndex: 0,
+    _clipboard: null,
+  });
+}
+
+describe('timeline action logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it('logs when addTrack changes state', () => {
+    useTimelineStore.getState().addTrack({ id: 'v1', type: 'video', name: 'V1', clips: [] });
+    expect(logAction).toHaveBeenCalledWith('addTrack', 'id=v1 type=video');
+  });
+
+  it('does not log toggleMute when the target track does not exist', () => {
+    useTimelineStore.getState().toggleMute('missing');
+    expect(logAction).not.toHaveBeenCalled();
+  });
+
+  it('does not log deleteSelectedClip when nothing is selected', () => {
+    useTimelineStore.getState().deleteSelectedClip();
+    expect(logAction).not.toHaveBeenCalled();
+  });
+
+  it('does not log pasteClip when clipboard is empty', () => {
+    useTimelineStore.getState().pasteClip();
+    expect(logAction).not.toHaveBeenCalled();
+  });
+
+  it('does not log undo when no history entry is available', () => {
+    useTimelineStore.getState().undo();
+    expect(logAction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- move timeline-store action logging out of Zustand updater callbacks
- skip logging for no-op actions that exit before any state transition
- add tests that lock the logging boundary in place

## Why
The timeline store still mixed state transitions with side effects by calling `logAction` inside `set((state) => ...)` updaters. That weakens referential transparency for the updater functions themselves.

This PR keeps the public store API intact and narrows the change to moving the logging side effect outside those updater callbacks.

## Changes
- update `trackSlice`, `clipSlice`, `historySlice`, and `clipboardSlice` to log before `set(...)`
- use `get()` for early validation in actions that may become no-ops
- keep the actual updater callbacks focused on state transformation only
- add `src/test/timelineActionLogger.test.ts` to verify representative logging and no-op behavior

## Verification
- `npm test -- src/test/timelineActionLogger.test.ts src/test/timelineStore.test.ts src/test/timelineStoreActions.test.ts`
- `npx eslint src/store/timeline/index.ts src/store/timeline/trackSlice.ts src/store/timeline/clipSlice.ts src/store/timeline/historySlice.ts src/store/timeline/clipboardSlice.ts src/test/timelineActionLogger.test.ts`

## Risk
Low. The store API and resulting state transitions are unchanged; the main behavioral difference is that no-op actions now avoid emitting action logs.
