### PR TITLE
moveKeyframeTime の dedup ループを再帰関数に置き換え

### DIFF
--- a/src/test/clipOperations.test.ts
+++ b/src/test/clipOperations.test.ts
@@ -5,6 +5,7 @@ import {
   removeKeyframeAtTime,
   updateKeyframeEasingAtTime,
   moveKeyframeTime,
+  deduplicateByTime,
 } from '../utils/clipOperations';
 import type { Clip, Keyframe } from '../store/timeline/types';
 
@@ -253,5 +254,58 @@ describe('moveKeyframeTime', () => {
     const existing = [makeKeyframe(1.0, 50), makeKeyframe(3.0, 80)];
     const result = moveKeyframeTime(existing, 1.0, 1.0);
     expect(result).toEqual(existing);
+  });
+});
+
+// ------------------------------------------------------------------
+// deduplicateByTime
+// ------------------------------------------------------------------
+describe('deduplicateByTime', () => {
+  it('returns empty array for empty input', () => {
+    expect(deduplicateByTime([])).toEqual([]);
+  });
+
+  it('returns single-element array unchanged', () => {
+    const input = [makeKeyframe(1.0, 50)];
+    expect(deduplicateByTime(input)).toEqual(input);
+  });
+
+  it('keeps the later element when two have the same time', () => {
+    const input = [makeKeyframe(2.0, 50), makeKeyframe(2.0, 80)];
+    const result = deduplicateByTime(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(80);
+  });
+
+  it('keeps the last when three or more share the same time', () => {
+    const input = [makeKeyframe(1.0, 10), makeKeyframe(1.0, 20), makeKeyframe(1.0, 30)];
+    const result = deduplicateByTime(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(30);
+  });
+
+  it('preserves distinct-time elements in order', () => {
+    const input = [makeKeyframe(1.0, 10), makeKeyframe(2.0, 20), makeKeyframe(3.0, 30)];
+    const result = deduplicateByTime(input);
+    expect(result).toEqual(input);
+  });
+
+  it('deduplicates only adjacent same-time groups', () => {
+    const input = [
+      makeKeyframe(1.0, 10),
+      makeKeyframe(1.0, 11),
+      makeKeyframe(3.0, 30),
+      makeKeyframe(3.0, 31),
+    ];
+    const result = deduplicateByTime(input);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(makeKeyframe(1.0, 11));
+    expect(result[1]).toEqual(makeKeyframe(3.0, 31));
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [makeKeyframe(1.0, 50), makeKeyframe(1.0, 80)];
+    deduplicateByTime(input);
+    expect(input).toHaveLength(2);
   });
 });

--- a/src/utils/clipOperations.ts
+++ b/src/utils/clipOperations.ts
@@ -75,15 +75,19 @@ export function moveKeyframeTime<T extends { time: number }>(
   const moved = existing.filter(isTarget).map(kf => ({ ...kf, time: toTime }) as T);
   // moved を後ろに配置: stable sort 後の dedup で移動した方が勝つ
   const sorted = [...unmoved, ...moved].sort((a, b) => a.time - b.time);
+  return deduplicateByTime(sorted);
+}
 
-  const deduped: T[] = [];
-  for (const kf of sorted) {
-    const last = deduped[deduped.length - 1];
-    if (last && Math.abs(last.time - kf.time) <= TIME_TOLERANCE) {
-      deduped[deduped.length - 1] = kf;
-    } else {
-      deduped.push(kf);
-    }
+/**
+ * 時刻順にソート済みの配列から、同一時刻（tolerance 内）の重複を除去する。
+ * 同一時刻が連続する場合、後の要素が勝つ（上書き）。
+ */
+export function deduplicateByTime<T extends { time: number }>(sorted: readonly T[]): T[] {
+  if (sorted.length <= 1) return [...sorted];
+  const [first, ...rest] = sorted;
+  const deduped = deduplicateByTime(rest);
+  if (deduped.length > 0 && Math.abs(first.time - deduped[0].time) <= TIME_TOLERANCE) {
+    return deduped;
   }
-  return deduped;
+  return [first, ...deduped];
 }


### PR DESCRIPTION
## Summary
- `moveKeyframeTime` 内の dedup `for` ループを再帰関数 `deduplicateByTime` に置き換え
- 同一時刻の重複除去が宣言的に表現される

## 手動テスト手順
- [ ] キーフレームの時刻移動で、既存キーフレームと重なった場合に移動した方が残ること