### PR TITLE
moveKeyframes のエフェクトキー for ループを mapClipKeyframes に置き換え

### DIFF
--- a/src/store/timeline/clipSlice.ts
+++ b/src/store/timeline/clipSlice.ts
@@ -8,6 +8,7 @@ import {
   removeKeyframeAtTime,
   updateKeyframeEasingAtTime,
   moveKeyframeTime,
+  mapClipKeyframes,
 } from '../../utils/clipOperations';
 
 type Set = StoreApi<TimelineState>['setState'];
@@ -239,12 +240,7 @@ export const createClipSlice = (set: Set, get: Get) => ({
               ...track,
               clips: track.clips.map(clip => {
                 if (clip.id !== clipId || !clip.keyframes) return clip;
-                const newKeyframes = { ...clip.keyframes } as typeof clip.keyframes;
-                for (const key of Object.keys(newKeyframes) as Array<keyof ClipEffects>) {
-                  const kfs = newKeyframes[key];
-                  if (!kfs) continue;
-                  newKeyframes[key] = moveKeyframeTime(kfs, fromTime, toTime);
-                }
+                const newKeyframes = mapClipKeyframes(clip.keyframes, kfs => moveKeyframeTime(kfs, fromTime, toTime));
                 return { ...clip, keyframes: newKeyframes };
               }),
             }

--- a/src/test/clipOperations.test.ts
+++ b/src/test/clipOperations.test.ts
@@ -5,8 +5,9 @@ import {
   removeKeyframeAtTime,
   updateKeyframeEasingAtTime,
   moveKeyframeTime,
+  mapClipKeyframes,
 } from '../utils/clipOperations';
-import type { Clip, Keyframe } from '../store/timeline/types';
+import type { Clip, Keyframe, ClipKeyframes } from '../store/timeline/types';
 
 function makeClip(overrides: Partial<Clip> = {}): Clip {
   return {
@@ -253,5 +254,41 @@ describe('moveKeyframeTime', () => {
     const existing = [makeKeyframe(1.0, 50), makeKeyframe(3.0, 80)];
     const result = moveKeyframeTime(existing, 1.0, 1.0);
     expect(result).toEqual(existing);
+  });
+});
+
+// ------------------------------------------------------------------
+// mapClipKeyframes
+// ------------------------------------------------------------------
+describe('mapClipKeyframes', () => {
+  it('applies fn to every effect key', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50)],
+      contrast: [makeKeyframe(2.0, 80)],
+    };
+    const result = mapClipKeyframes(keyframes, kfs => kfs.map(kf => ({ ...kf, value: kf.value * 2 })));
+    expect(result.brightness![0].value).toBe(100);
+    expect(result.contrast![0].value).toBe(160);
+  });
+
+  it('preserves keys where fn returns the same array', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50)],
+    };
+    const result = mapClipKeyframes(keyframes, kfs => kfs);
+    expect(result.brightness).toEqual(keyframes.brightness);
+  });
+
+  it('does not mutate the input object', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50)],
+    };
+    mapClipKeyframes(keyframes, kfs => kfs.map(kf => ({ ...kf, value: 0 })));
+    expect(keyframes.brightness![0].value).toBe(50);
+  });
+
+  it('handles empty keyframes object', () => {
+    const result = mapClipKeyframes({}, kfs => kfs);
+    expect(Object.keys(result)).toHaveLength(0);
   });
 });

--- a/src/utils/clipOperations.ts
+++ b/src/utils/clipOperations.ts
@@ -1,4 +1,4 @@
-import type { Clip, EasingType } from '../store/timeline/types';
+import type { Clip, ClipKeyframes, Keyframe, EasingType } from '../store/timeline/types';
 
 export const TIME_TOLERANCE = 0.001;
 
@@ -86,4 +86,16 @@ export function moveKeyframeTime<T extends { time: number }>(
     }
   }
   return deduped;
+}
+
+/**
+ * ClipKeyframes の全エフェクトキーに変換関数を適用して新しい ClipKeyframes を返す。
+ */
+export function mapClipKeyframes(
+  keyframes: ClipKeyframes,
+  fn: (kfs: Keyframe[]) => Keyframe[],
+): ClipKeyframes {
+  return Object.fromEntries(
+    Object.entries(keyframes).map(([key, kfs]) => [key, kfs ? fn(kfs) : kfs]),
+  ) as ClipKeyframes;
 }


### PR DESCRIPTION
## Summary
- `clipOperations.ts` に `mapClipKeyframes` 純粋関数を追加
- `clipSlice.ts` の `moveKeyframes` 内の `for` ループ + オブジェクト代入を `mapClipKeyframes` 呼び出しに置き換え

## 手動テスト手順
- [ ] 複数エフェクトキーにキーフレームを設定し、時刻移動が全キーに適用されること