### PR TITLE
deleteKeyframesAtTime のエフェクトキー for ループを compactClipKeyframes に置き換え

### DIFF
--- a/src/store/timeline/clipSlice.ts
+++ b/src/store/timeline/clipSlice.ts
@@ -8,6 +8,7 @@ import {
   removeKeyframeAtTime,
   updateKeyframeEasingAtTime,
   moveKeyframeTime,
+  compactClipKeyframes,
 } from '../../utils/clipOperations';
 
 type Set = StoreApi<TimelineState>['setState'];
@@ -263,19 +264,8 @@ export const createClipSlice = (set: Set, get: Get) => ({
               ...track,
               clips: track.clips.map(clip => {
                 if (clip.id !== clipId || !clip.keyframes) return clip;
-                const newKeyframes = { ...clip.keyframes } as typeof clip.keyframes;
-                for (const key of Object.keys(newKeyframes) as Array<keyof ClipEffects>) {
-                  const kfs = newKeyframes[key];
-                  if (!kfs) continue;
-                  const updated = removeKeyframeAtTime(kfs, time);
-                  if (updated.length === 0) {
-                    delete newKeyframes[key];
-                  } else {
-                    newKeyframes[key] = updated;
-                  }
-                }
-                const hasKeys = Object.keys(newKeyframes).length > 0;
-                return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
+                const newKeyframes = compactClipKeyframes(clip.keyframes, kfs => removeKeyframeAtTime(kfs, time));
+                return { ...clip, keyframes: newKeyframes };
               }),
             }
           : track

--- a/src/test/clipOperations.test.ts
+++ b/src/test/clipOperations.test.ts
@@ -5,8 +5,9 @@ import {
   removeKeyframeAtTime,
   updateKeyframeEasingAtTime,
   moveKeyframeTime,
+  compactClipKeyframes,
 } from '../utils/clipOperations';
-import type { Clip, Keyframe } from '../store/timeline/types';
+import type { Clip, Keyframe, ClipKeyframes } from '../store/timeline/types';
 
 function makeClip(overrides: Partial<Clip> = {}): Clip {
   return {
@@ -253,5 +254,53 @@ describe('moveKeyframeTime', () => {
     const existing = [makeKeyframe(1.0, 50), makeKeyframe(3.0, 80)];
     const result = moveKeyframeTime(existing, 1.0, 1.0);
     expect(result).toEqual(existing);
+  });
+});
+
+// ------------------------------------------------------------------
+// compactClipKeyframes
+// ------------------------------------------------------------------
+describe('compactClipKeyframes', () => {
+  it('applies fn and keeps non-empty results', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50), makeKeyframe(2.0, 80)],
+      contrast: [makeKeyframe(1.0, 30)],
+    };
+    // time=1.0 のキーフレームだけ除去
+    const result = compactClipKeyframes(keyframes, kfs => kfs.filter(kf => kf.time !== 1.0));
+    expect(result).toBeDefined();
+    expect(result!.brightness).toHaveLength(1);
+    expect(result!.brightness![0].time).toBe(2.0);
+    expect(result!.contrast).toBeUndefined(); // 空になったキーは除去される
+  });
+
+  it('returns undefined when all keys become empty', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50)],
+    };
+    const result = compactClipKeyframes(keyframes, () => []);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns all keys when none become empty', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50)],
+      contrast: [makeKeyframe(2.0, 80)],
+    };
+    const result = compactClipKeyframes(keyframes, kfs => kfs);
+    expect(result).toEqual(keyframes);
+  });
+
+  it('does not mutate the input object', () => {
+    const keyframes: ClipKeyframes = {
+      brightness: [makeKeyframe(1.0, 50)],
+    };
+    compactClipKeyframes(keyframes, () => []);
+    expect(keyframes.brightness).toHaveLength(1);
+  });
+
+  it('handles empty keyframes object', () => {
+    const result = compactClipKeyframes({}, kfs => kfs);
+    expect(result).toBeUndefined();
   });
 });

--- a/src/utils/clipOperations.ts
+++ b/src/utils/clipOperations.ts
@@ -1,4 +1,4 @@
-import type { Clip, EasingType } from '../store/timeline/types';
+import type { Clip, ClipKeyframes, Keyframe, EasingType } from '../store/timeline/types';
 
 export const TIME_TOLERANCE = 0.001;
 
@@ -86,4 +86,20 @@ export function moveKeyframeTime<T extends { time: number }>(
     }
   }
   return deduped;
+}
+
+/**
+ * ClipKeyframes の全エフェクトキーに変換関数を適用し、空になったキーを除去して返す。
+ * 全キーが空になった場合は undefined を返す。
+ */
+export function compactClipKeyframes(
+  keyframes: ClipKeyframes,
+  fn: (kfs: Keyframe[]) => Keyframe[],
+): ClipKeyframes | undefined {
+  const entries = Object.entries(keyframes).reduce<[string, Keyframe[]][]>((acc, [key, kfs]) => {
+    if (!kfs) return acc;
+    const updated = fn(kfs);
+    return updated.length > 0 ? [...acc, [key, updated]] : acc;
+  }, []);
+  return entries.length > 0 ? Object.fromEntries(entries) as ClipKeyframes : undefined;
 }


### PR DESCRIPTION
## Summary
- `clipOperations.ts` に `compactClipKeyframes` 純粋関数を追加（変換 + 空キー除去 + 全空時 undefined）
- `clipSlice.ts` の `deleteKeyframesAtTime` 内の `for` ループ + `delete` を `compactClipKeyframes` 呼び出しに置き換え

## 手動テスト手順
- [ ] キーフレームを追加し、特定時刻のキーフレーム一括削除が正常に動作すること
- [ ] 全キーフレーム削除後に `keyframes` が `undefined` になること