### PR TITLE
updateClipInTracks ヘルパーを抽出し clipSlice のネストを削減

### DIFF
--- a/src/store/timeline/clipSlice.ts
+++ b/src/store/timeline/clipSlice.ts
@@ -10,6 +10,7 @@ import {
   moveKeyframeTime,
   mapClipKeyframes,
   compactClipKeyframes,
+  updateClipInTracks,
 } from '../../utils/clipOperations';
 
 type Set = StoreApi<TimelineState>['setState'];
@@ -52,33 +53,14 @@ export const createClipSlice = (set: Set, get: Get) => ({
   updateClip: (trackId: string, clipId: string, updates: Partial<Clip>) => {
     logAction('updateClip', `track=${trackId} clip=${clipId} keys=${Object.keys(updates).join(',')}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip =>
-                clip.id === clipId ? { ...clip, ...updates } : clip
-              ),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => ({ ...clip, ...updates }));
       return withHistory(state, newTracks);
     });
   },
 
-  updateClipSilent: (trackId: string, clipId: string, updates: Partial<Clip>) => set((state) => {
-    const newTracks = state.tracks.map(track =>
-      track.id === trackId
-        ? {
-            ...track,
-            clips: track.clips.map(clip =>
-              clip.id === clipId ? { ...clip, ...updates } : clip
-            ),
-          }
-        : track
-    );
-    return { tracks: newTracks };
-  }),
+  updateClipSilent: (trackId: string, clipId: string, updates: Partial<Clip>) => set((state) => ({
+    tracks: updateClipInTracks(state.tracks, trackId, clipId, clip => ({ ...clip, ...updates })),
+  })),
 
   splitClipAtTime: (trackId: string, clipId: string, splitTime: number) => {
     const track = get().tracks.find(t => t.id === trackId);
@@ -135,16 +117,7 @@ export const createClipSlice = (set: Set, get: Get) => ({
   setTransition: (trackId: string, clipId: string, transition: ClipTransition) => {
     logAction('setTransition', `track=${trackId} clip=${clipId} type=${transition.type}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip =>
-                clip.id === clipId ? { ...clip, transition } : clip
-              ),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => ({ ...clip, transition }));
       return withHistory(state, newTracks);
     });
   },
@@ -152,16 +125,7 @@ export const createClipSlice = (set: Set, get: Get) => ({
   removeTransition: (trackId: string, clipId: string) => {
     logAction('removeTransition', `track=${trackId} clip=${clipId}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip =>
-                clip.id === clipId ? { ...clip, transition: undefined } : clip
-              ),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => ({ ...clip, transition: undefined }));
       return withHistory(state, newTracks);
     });
   },
@@ -169,22 +133,11 @@ export const createClipSlice = (set: Set, get: Get) => ({
   addKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, keyframe: Keyframe) => {
     logAction('addKeyframe', `track=${trackId} clip=${clipId} key=${effectKey} time=${keyframe.time.toFixed(2)}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId) return clip;
-                const existing = clip.keyframes?.[effectKey] ?? [];
-                const updated = upsertKeyframe(existing, keyframe);
-                return {
-                  ...clip,
-                  keyframes: { ...clip.keyframes, [effectKey]: updated },
-                };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        const existing = clip.keyframes?.[effectKey] ?? [];
+        const updated = upsertKeyframe(existing, keyframe);
+        return { ...clip, keyframes: { ...clip.keyframes, [effectKey]: updated } };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -192,22 +145,14 @@ export const createClipSlice = (set: Set, get: Get) => ({
   removeKeyframe: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number) => {
     logAction('removeKeyframe', `track=${trackId} clip=${clipId} key=${effectKey} time=${time.toFixed(2)}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId) return clip;
-                const existing = clip.keyframes?.[effectKey] ?? [];
-                const updated = removeKeyframeAtTime(existing, time);
-                const newKeyframes = { ...clip.keyframes, [effectKey]: updated };
-                if (updated.length === 0) delete newKeyframes[effectKey];
-                const hasKeys = Object.keys(newKeyframes).length > 0;
-                return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        const existing = clip.keyframes?.[effectKey] ?? [];
+        const updated = removeKeyframeAtTime(existing, time);
+        const newKeyframes = { ...clip.keyframes, [effectKey]: updated };
+        if (updated.length === 0) delete newKeyframes[effectKey];
+        const hasKeys = Object.keys(newKeyframes).length > 0;
+        return { ...clip, keyframes: hasKeys ? newKeyframes : undefined };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -215,19 +160,11 @@ export const createClipSlice = (set: Set, get: Get) => ({
   updateKeyframeEasing: (trackId: string, clipId: string, effectKey: keyof ClipEffects, time: number, easing: EasingType) => {
     logAction('updateKeyframeEasing', `track=${trackId} clip=${clipId} key=${effectKey} time=${time.toFixed(2)} easing=${easing}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId) return clip;
-                const existing = clip.keyframes?.[effectKey] ?? [];
-                const updated = updateKeyframeEasingAtTime(existing, time, easing);
-                return { ...clip, keyframes: { ...clip.keyframes, [effectKey]: updated } };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        const existing = clip.keyframes?.[effectKey] ?? [];
+        const updated = updateKeyframeEasingAtTime(existing, time, easing);
+        return { ...clip, keyframes: { ...clip.keyframes, [effectKey]: updated } };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -235,18 +172,10 @@ export const createClipSlice = (set: Set, get: Get) => ({
   moveKeyframes: (trackId: string, clipId: string, fromTime: number, toTime: number) => {
     logAction('moveKeyframes', `track=${trackId} clip=${clipId} from=${fromTime.toFixed(2)} to=${toTime.toFixed(2)}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId || !clip.keyframes) return clip;
-                const newKeyframes = mapClipKeyframes(clip.keyframes, kfs => moveKeyframeTime(kfs, fromTime, toTime));
-                return { ...clip, keyframes: newKeyframes };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        if (!clip.keyframes) return clip;
+        return { ...clip, keyframes: mapClipKeyframes(clip.keyframes, kfs => moveKeyframeTime(kfs, fromTime, toTime)) };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -254,18 +183,10 @@ export const createClipSlice = (set: Set, get: Get) => ({
   deleteKeyframesAtTime: (trackId: string, clipId: string, time: number) => {
     logAction('deleteKeyframesAtTime', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId || !clip.keyframes) return clip;
-                const newKeyframes = compactClipKeyframes(clip.keyframes, kfs => removeKeyframeAtTime(kfs, time));
-                return { ...clip, keyframes: newKeyframes };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        if (!clip.keyframes) return clip;
+        return { ...clip, keyframes: compactClipKeyframes(clip.keyframes, kfs => removeKeyframeAtTime(kfs, time)) };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -273,19 +194,10 @@ export const createClipSlice = (set: Set, get: Get) => ({
   addToneCurveKeyframe: (trackId: string, clipId: string, keyframe: ToneCurveKeyframe) => {
     logAction('addToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${keyframe.time.toFixed(2)}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId) return clip;
-                const existing = clip.toneCurveKeyframes ?? [];
-                const updated = upsertKeyframe(existing, keyframe);
-                return { ...clip, toneCurveKeyframes: updated };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        const existing = clip.toneCurveKeyframes ?? [];
+        return { ...clip, toneCurveKeyframes: upsertKeyframe(existing, keyframe) };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -293,19 +205,11 @@ export const createClipSlice = (set: Set, get: Get) => ({
   removeToneCurveKeyframe: (trackId: string, clipId: string, time: number) => {
     logAction('removeToneCurveKeyframe', `track=${trackId} clip=${clipId} time=${time.toFixed(2)}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId) return clip;
-                const existing = clip.toneCurveKeyframes ?? [];
-                const updated = removeKeyframeAtTime(existing, time);
-                return { ...clip, toneCurveKeyframes: updated.length > 0 ? updated : undefined };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        const existing = clip.toneCurveKeyframes ?? [];
+        const updated = removeKeyframeAtTime(existing, time);
+        return { ...clip, toneCurveKeyframes: updated.length > 0 ? updated : undefined };
+      });
       return withHistory(state, newTracks);
     });
   },
@@ -313,19 +217,10 @@ export const createClipSlice = (set: Set, get: Get) => ({
   updateToneCurveKeyframeEasing: (trackId: string, clipId: string, time: number, easing: EasingType) => {
     logAction('updateToneCurveKeyframeEasing', `track=${trackId} clip=${clipId} time=${time.toFixed(2)} easing=${easing}`);
     set((state) => {
-      const newTracks = state.tracks.map(track =>
-        track.id === trackId
-          ? {
-              ...track,
-              clips: track.clips.map(clip => {
-                if (clip.id !== clipId) return clip;
-                const existing = clip.toneCurveKeyframes ?? [];
-                const updated = updateKeyframeEasingAtTime(existing, time, easing);
-                return { ...clip, toneCurveKeyframes: updated };
-              }),
-            }
-          : track
-      );
+      const newTracks = updateClipInTracks(state.tracks, trackId, clipId, clip => {
+        const existing = clip.toneCurveKeyframes ?? [];
+        return { ...clip, toneCurveKeyframes: updateKeyframeEasingAtTime(existing, time, easing) };
+      });
       return withHistory(state, newTracks);
     });
   },

--- a/src/test/clipOperations.test.ts
+++ b/src/test/clipOperations.test.ts
@@ -444,4 +444,14 @@ describe('updateClipInTracks', () => {
     const result = updateClipInTracks(tracks, 't1', 'c1', clip => ({ ...clip, name: 'X' }));
     expect(result[0].clips[1]).toBe(tracks[0].clips[1]);
   });
+
+  it('returns empty array for empty tracks input', () => {
+    const result = updateClipInTracks([], 't1', 'c1', clip => ({ ...clip, name: 'X' }));
+    expect(result).toEqual([]);
+  });
+
+  it('returns same values when fn is identity', () => {
+    const result = updateClipInTracks(tracks, 't1', 'c1', clip => clip);
+    expect(result[0].clips[0]).toBe(tracks[0].clips[0]);
+  });
 });

--- a/src/test/clipOperations.test.ts
+++ b/src/test/clipOperations.test.ts
@@ -8,8 +8,9 @@ import {
   deduplicateByTime,
   mapClipKeyframes,
   compactClipKeyframes,
+  updateClipInTracks,
 } from '../utils/clipOperations';
-import type { Clip, Keyframe, ClipKeyframes } from '../store/timeline/types';
+import type { Clip, Keyframe, ClipKeyframes, Track } from '../store/timeline/types';
 
 function makeClip(overrides: Partial<Clip> = {}): Clip {
   return {
@@ -392,5 +393,55 @@ describe('deduplicateByTime', () => {
     const input = [makeKeyframe(1.0, 50), makeKeyframe(1.0, 80)];
     deduplicateByTime(input);
     expect(input).toHaveLength(2);
+  });
+});
+
+// ------------------------------------------------------------------
+// updateClipInTracks
+// ------------------------------------------------------------------
+function makeTrack(id: string, clips: Clip[]): Track {
+  return { id, type: 'video', name: `Track ${id}`, clips, volume: 1, mute: false, solo: false };
+}
+
+describe('updateClipInTracks', () => {
+  const clip1 = makeClip({ id: 'c1', name: 'Clip 1' });
+  const clip2 = makeClip({ id: 'c2', name: 'Clip 2' });
+  const tracks: Track[] = [
+    makeTrack('t1', [clip1, clip2]),
+    makeTrack('t2', [makeClip({ id: 'c3', name: 'Clip 3' })]),
+  ];
+
+  it('applies fn only to the matching clip', () => {
+    const result = updateClipInTracks(tracks, 't1', 'c1', clip => ({ ...clip, name: 'Updated' }));
+    expect(result[0].clips[0].name).toBe('Updated');
+    expect(result[0].clips[1].name).toBe('Clip 2');
+    expect(result[1].clips[0].name).toBe('Clip 3');
+  });
+
+  it('returns unchanged tracks when trackId does not match', () => {
+    const result = updateClipInTracks(tracks, 'nonexistent', 'c1', clip => ({ ...clip, name: 'X' }));
+    expect(result[0].clips[0].name).toBe('Clip 1');
+  });
+
+  it('returns unchanged tracks when clipId does not match', () => {
+    const result = updateClipInTracks(tracks, 't1', 'nonexistent', clip => ({ ...clip, name: 'X' }));
+    expect(result[0].clips[0].name).toBe('Clip 1');
+    expect(result[0].clips[1].name).toBe('Clip 2');
+  });
+
+  it('does not mutate the input tracks array', () => {
+    const originalName = tracks[0].clips[0].name;
+    updateClipInTracks(tracks, 't1', 'c1', clip => ({ ...clip, name: 'Changed' }));
+    expect(tracks[0].clips[0].name).toBe(originalName);
+  });
+
+  it('preserves referential identity for non-matching tracks', () => {
+    const result = updateClipInTracks(tracks, 't1', 'c1', clip => ({ ...clip, name: 'X' }));
+    expect(result[1]).toBe(tracks[1]);
+  });
+
+  it('preserves referential identity for non-matching clips in the same track', () => {
+    const result = updateClipInTracks(tracks, 't1', 'c1', clip => ({ ...clip, name: 'X' }));
+    expect(result[0].clips[1]).toBe(tracks[0].clips[1]);
   });
 });

--- a/src/utils/clipOperations.ts
+++ b/src/utils/clipOperations.ts
@@ -1,4 +1,4 @@
-import type { Clip, ClipKeyframes, Keyframe, EasingType } from '../store/timeline/types';
+import type { Clip, ClipKeyframes, Keyframe, EasingType, Track } from '../store/timeline/types';
 
 export const TIME_TOLERANCE = 0.001;
 
@@ -118,4 +118,21 @@ export function compactClipKeyframes(
     return updated.length > 0 ? [...acc, [key, updated]] : acc;
   }, []);
   return entries.length > 0 ? Object.fromEntries(entries) as ClipKeyframes : undefined;
+}
+
+/**
+ * 指定 trackId/clipId のクリップに変換関数を適用した新しい tracks 配列を返す。
+ * マッチしないトラック・クリップは参照をそのまま保持する。
+ */
+export function updateClipInTracks(
+  tracks: readonly Track[],
+  trackId: string,
+  clipId: string,
+  fn: (clip: Clip) => Clip,
+): Track[] {
+  return tracks.map(track =>
+    track.id === trackId
+      ? { ...track, clips: track.clips.map(clip => clip.id === clipId ? fn(clip) : clip) }
+      : track,
+  );
 }


### PR DESCRIPTION
## Summary
- `clipOperations.ts` に `updateClipInTracks` 純粋関数を追加（指定 trackId/clipId のクリップに変換関数を適用）
- `clipSlice.ts` の12アクションを `updateClipInTracks` で書き直し、ネストを 7-8段 → 4段に削減
- `+116 -153` で行数も減少

## 適用した12アクション
updateClip, updateClipSilent, setTransition, removeTransition, addKeyframe, removeKeyframe, updateKeyframeEasing, moveKeyframes, deleteKeyframesAtTime, addToneCurveKeyframe, removeToneCurveKeyframe, updateToneCurveKeyframeEasing

## 適用しなかったもの（パターンが異なる）
addClip (append), removeClip (filter+空トラック除去), deleteSelectedClip (get事前取得), splitClipAtTime (flatMap), moveClipToTrack (2トラック同時)

## 手動テスト手順
- [ ] クリップのエフェクト変更（brightness, contrast 等）が正常に動作すること
- [ ] キーフレームの追加・削除・移動・easing変更が正常に動作すること
- [ ] トランジションの設定・解除が正常に動作すること
- [ ] トーンカーブキーフレームの追加・削除・easing変更が正常に動作すること
- [ ] Undo/Redo が全操作で正常に動作すること