### PR TITLE
パス抽出ロジックを純粋関数に抽出し projectStore の重複を解消

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -9,6 +9,7 @@ import { useExportStore } from './exportStore';
 import { useVideoPreviewStore } from './videoPreviewStore';
 import i18n from '../i18n';
 import { toRelativePath, resolveRelativePath, getDirectoryPath } from '../utils/pathUtils';
+import { extractDisplayName, extractProjectName } from '../utils/projectPaths';
 import {
   clearAutosaveFilePath,
   createAutosaveRuntimeState,
@@ -316,9 +317,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
       applyProjectToStores(resolvedProject);
 
-      const name = path.split('/').pop()?.replace(/\.qcut$/, '')
-        ?? path.split('\\').pop()?.replace(/\.qcut$/, '')
-        ?? project.metadata.name;
+      const name = extractProjectName(path, project.metadata.name);
 
       set({
         projectFilePath: path,
@@ -416,9 +415,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           const project = validateProjectFile(parsed);
 
           const originalPath = project.metadata.originalPath;
-          const displayName = originalPath
-            ? (originalPath.split('/').pop() ?? originalPath.split('\\').pop() ?? project.metadata.name)
-            : project.metadata.name;
+          const displayName = extractDisplayName(originalPath, project.metadata.name);
 
           const recover = await ask(
             i18n.t('project.autosaveRecover', { name: displayName }),
@@ -432,11 +429,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
             const projectDir = originalPath ? getDirectoryPath(originalPath) : '';
             applyProjectToStores(withResolvedProjectClipPaths(project, projectDir));
 
-            const name = originalPath
-              ? (originalPath.split('/').pop()?.replace(/\.qcut$/, '')
-                ?? originalPath.split('\\').pop()?.replace(/\.qcut$/, '')
-                ?? project.metadata.name)
-              : project.metadata.name;
+            const name = extractProjectName(originalPath, project.metadata.name);
 
             set({
               projectFilePath: originalPath ?? null,

--- a/src/test/projectPaths.test.ts
+++ b/src/test/projectPaths.test.ts
@@ -10,12 +10,20 @@ describe('extractDisplayName', () => {
     expect(extractDisplayName('C:\\Users\\test\\project.qcut', 'fallback')).toBe('project.qcut');
   });
 
+  it('extracts filename from mixed-separator path', () => {
+    expect(extractDisplayName('C:/Users\\test/project.qcut', 'fallback')).toBe('project.qcut');
+  });
+
   it('returns fallback when path is undefined', () => {
     expect(extractDisplayName(undefined, 'My Project')).toBe('My Project');
   });
 
   it('returns fallback when path is empty string', () => {
     expect(extractDisplayName('', 'My Project')).toBe('My Project');
+  });
+
+  it('returns fallback when path ends with separator', () => {
+    expect(extractDisplayName('/Users/test/', 'fallback')).toBe('fallback');
   });
 
   it('returns filename for path without directory', () => {
@@ -32,6 +40,10 @@ describe('extractProjectName', () => {
     expect(extractProjectName('C:\\Users\\test\\myproject.qcut', 'fallback')).toBe('myproject');
   });
 
+  it('extracts name from mixed-separator path', () => {
+    expect(extractProjectName('C:/Users\\test/myproject.qcut', 'fallback')).toBe('myproject');
+  });
+
   it('returns name without extension when no .qcut suffix', () => {
     expect(extractProjectName('/Users/test/myproject', 'fallback')).toBe('myproject');
   });
@@ -46,6 +58,14 @@ describe('extractProjectName', () => {
 
   it('returns fallback when path is empty string', () => {
     expect(extractProjectName('', 'Default')).toBe('Default');
+  });
+
+  it('returns fallback when path ends with separator', () => {
+    expect(extractProjectName('/Users/test/', 'Default')).toBe('Default');
+  });
+
+  it('returns fallback when filename is just .qcut', () => {
+    expect(extractProjectName('/Users/test/.qcut', 'Default')).toBe('Default');
   });
 
   it('handles filename-only path', () => {

--- a/src/test/projectPaths.test.ts
+++ b/src/test/projectPaths.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { extractDisplayName, extractProjectName } from '../utils/projectPaths';
+
+describe('extractDisplayName', () => {
+  it('extracts filename from Unix path', () => {
+    expect(extractDisplayName('/Users/test/project.qcut', 'fallback')).toBe('project.qcut');
+  });
+
+  it('extracts filename from Windows path', () => {
+    expect(extractDisplayName('C:\\Users\\test\\project.qcut', 'fallback')).toBe('project.qcut');
+  });
+
+  it('returns fallback when path is undefined', () => {
+    expect(extractDisplayName(undefined, 'My Project')).toBe('My Project');
+  });
+
+  it('returns fallback when path is empty string', () => {
+    expect(extractDisplayName('', 'My Project')).toBe('My Project');
+  });
+
+  it('returns filename for path without directory', () => {
+    expect(extractDisplayName('project.qcut', 'fallback')).toBe('project.qcut');
+  });
+});
+
+describe('extractProjectName', () => {
+  it('extracts name and removes .qcut extension from Unix path', () => {
+    expect(extractProjectName('/Users/test/myproject.qcut', 'fallback')).toBe('myproject');
+  });
+
+  it('extracts name and removes .qcut extension from Windows path', () => {
+    expect(extractProjectName('C:\\Users\\test\\myproject.qcut', 'fallback')).toBe('myproject');
+  });
+
+  it('returns name without extension when no .qcut suffix', () => {
+    expect(extractProjectName('/Users/test/myproject', 'fallback')).toBe('myproject');
+  });
+
+  it('returns fallback when path is undefined', () => {
+    expect(extractProjectName(undefined, 'Default')).toBe('Default');
+  });
+
+  it('returns fallback when path is null', () => {
+    expect(extractProjectName(null, 'Default')).toBe('Default');
+  });
+
+  it('returns fallback when path is empty string', () => {
+    expect(extractProjectName('', 'Default')).toBe('Default');
+  });
+
+  it('handles filename-only path', () => {
+    expect(extractProjectName('video.qcut', 'fallback')).toBe('video');
+  });
+});

--- a/src/utils/projectPaths.ts
+++ b/src/utils/projectPaths.ts
@@ -4,7 +4,8 @@
  */
 export function extractDisplayName(path: string | undefined, fallback: string): string {
   if (!path) return fallback;
-  return path.split('/').pop()?.split('\\').pop() ?? fallback;
+  const filename = path.split('/').pop()?.split('\\').pop();
+  return filename || fallback;
 }
 
 /**
@@ -15,5 +16,6 @@ export function extractProjectName(path: string | undefined | null, fallback: st
   if (!path) return fallback;
   const filename = path.split('/').pop()?.split('\\').pop();
   if (!filename) return fallback;
-  return filename.replace(/\.qcut$/, '');
+  const name = filename.replace(/\.qcut$/, '');
+  return name || fallback;
 }

--- a/src/utils/projectPaths.ts
+++ b/src/utils/projectPaths.ts
@@ -1,0 +1,19 @@
+/**
+ * ファイルパスからファイル名を取得する。
+ * Unix / Windows 両方のセパレータに対応。パスが空や undefined なら fallback を返す。
+ */
+export function extractDisplayName(path: string | undefined, fallback: string): string {
+  if (!path) return fallback;
+  return path.split('/').pop()?.split('\\').pop() ?? fallback;
+}
+
+/**
+ * ファイルパスから .qcut 拡張子を除去したプロジェクト名を取得する。
+ * パスが空・null・undefined なら fallback を返す。
+ */
+export function extractProjectName(path: string | undefined | null, fallback: string): string {
+  if (!path) return fallback;
+  const filename = path.split('/').pop()?.split('\\').pop();
+  if (!filename) return fallback;
+  return filename.replace(/\.qcut$/, '');
+}


### PR DESCRIPTION
## Summary
- `src/utils/projectPaths.ts` に `extractDisplayName` / `extractProjectName` 純粋関数を追加
- `projectStore.ts` の3箇所のインラインパス抽出（三項演算子 + optional chaining の重複）を関数呼び出しに置き換え

## 適用箇所
| 関数 | 行 | Before | After |
|------|-----|--------|-------|
| `loadProjectFromPath` | 319-321 | `path.split('/').pop()?.replace(...)  ?? ...` | `extractProjectName(path, ...)` |
| `checkAndRecoverAutosave` | 419-421 | `originalPath.split('/').pop() ?? ...` | `extractDisplayName(originalPath, ...)` |
| `checkAndRecoverAutosave` | 435-439 | `originalPath.split('/').pop()?.replace(...) ?? ...` | `extractProjectName(originalPath, ...)` |

## 手動テスト手順
- [ ] プロジェクトファイルを開いてタイトルバーに正しい名前が表示されること
- [ ] 自動保存の復旧ダイアログに正しいファイル名が表示されること